### PR TITLE
fleet: systemd script & fleet bootstrap for sumologic

### DIFF
--- a/v1/fleet_bootstrap.sh
+++ b/v1/fleet_bootstrap.sh
@@ -32,9 +32,16 @@ fi
 # update the scripts with zookeeper value
 sed -i "s/<ZK_ELB>/$ZOOKEEPER/g" *.service
 
+
 # setup datadog
 read -p "Enter datadog api key for this account: " DATADOG_KEY
 etcdctl set /ddapikey $DATADOG_KEY
+
+# set sumologic credentials
+read -p "sumologic access ID: " SUMOLOGIC_ACCESS_ID
+read -p "sumologic secret key: " SUMOLOGIC_SECRET
+etcdctl set /sumologic_id $SUMOLOGIC_ACCESS_ID
+etcdctl set /sumologic_secret $SUMOLOGIC_SECRET
 
 # start each of the services
 SERVICES="

--- a/v1/fleet_units/sumologic.service
+++ b/v1/fleet_units/sumologic.service
@@ -16,9 +16,10 @@ ExecStart=/usr/bin/bash -c \
     -v /var/lib/docker/containers/:/tmp/clogs/
     -e SUMO_NAME=docker_cluster \
     -e SUMO_CATEGORY=container_logs \
-    behance/docker-sumologic \
-    `etcdctl get /sumologic_id` \
-    `etcdctl get /sumologic_secret`"
+    -e SUMO_COLLECTOR_NAME=mesos_app_collector \
+    -e SUMO_ACCESS_ID=`etcdctl get /sumologic_id` \
+    -e SUMO_ACCESS_KEY=`etcdctl get /sumologic_secret` \
+    behance/docker-sumologic"
 ExecStop=/usr/bin/docker stop sumologic
 
 [X-Fleet]

--- a/v1/fleet_units/sumologic.service
+++ b/v1/fleet_units/sumologic.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Sumologic Collector
+After=docker.service
+
+[Service]
+Restart=always
+ExecStartPre=-/usr/bin/docker stop sumologic
+ExecStartPre=-/usr/bin/docker rm -f sumologic
+ExecStartPre=/usr/bin/docker pull behance/docker-sumologic
+TimeoutStartSec=0
+ExecStartPre=-/usr/bin/docker kill sumologic
+ExecStartPre=-/usr/bin/docker rm sumologic
+ExecStart=/usr/bin/bash -c \
+    "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
+    /usr/bin/docker run --name sumologic \
+    -v /var/lib/docker/containers/:/tmp/clogs/
+    -e SUMO_NAME=docker_cluster \
+    -e SUMO_CATEGORY=container_logs \
+    behance/docker-sumologic \
+    `etcdctl get /sumologic_id` \
+    `etcdctl get /sumologic_secret`"
+ExecStop=/usr/bin/docker stop sumologic
+
+[X-Fleet]
+Global=true

--- a/v1/fleet_units/sumologic.service
+++ b/v1/fleet_units/sumologic.service
@@ -13,7 +13,7 @@ ExecStartPre=-/usr/bin/docker rm sumologic
 ExecStart=/usr/bin/bash -c \
     "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
     /usr/bin/docker run --name sumologic \
-    -v /var/lib/docker/containers/:/tmp/clogs/
+    -v /var/lib/docker/containers/:/tmp/clogs/:ro
     -e SUMO_NAME=docker_cluster \
     -e SUMO_CATEGORY=container_logs \
     -e SUMO_COLLECTOR_NAME=mesos_app_collector \


### PR DESCRIPTION
This assumes that sumologic is configured to read from the `docker_cluster` source, `container_logs` category.

By default (assuming no docker logging drivers used) all logs being collected will be in the default docker JSON log format.
