### PR TITLE
Marathon uses zookeeper on localhost

### DIFF
--- a/v1/fleet_units/marathon.service
+++ b/v1/fleet_units/marathon.service
@@ -1,14 +1,12 @@
 [Unit]
 Description=Marathon
-After=docker.service mesos-master.service
-Requires=docker.service
+After=docker.service zookeeper-exhibitor.service mesos-master.service
+Requires=docker.service 
+Wants=zookeeper-exhibitor.service
 
 [Service]
 Environment=MARATHON_IMAGE=mesosphere/marathon:v0.9.0
-Environment=ZOOKEEPER=<ZK_ELB>
-
-# Example of what it should resolve to
-# Environment=ZOOKEEPER=internal-coreos-control-etcd-852307729.us-west-2.elb.amazonaws.com:2181
+Environment=ZOOKEEPER=localhost:2181
 
 User=core
 Restart=always


### PR DESCRIPTION
Marathon only resolves host names once. So if an underlying ZK ELB node is replaced, Marathon continues to try to connect to the missing node. Using localhost will always provide a valid ZK endpoint. Testing shows no ill affects to cluster health if one node loses ZK.
