### PR TITLE
init: check/set bootstrapped flag

### DIFF
--- a/init
+++ b/init
@@ -1,5 +1,10 @@
 #!/usr/bin/bash
 
+if [ "$(etcdctl get bootstrapped)" == "true" ]; then
+    exit 0
+fi
+etcdctl set bootstrapped true
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 HOMEDIR=$(eval echo "~`whoami`")
 


### PR DESCRIPTION
This prevents secure ENV vars such as DB passwords from being set to the default, after possible manual changes.
