### PR TITLE
etcd image IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,34 @@ Assumptions:
 - ALL nodes run a `bootstrap.service`, whatever that may be.
 - Some of the scripts require `/etc/environment` to contain certain variables (usually cloudformation parameters such as route53 entries)
 - S3 buckets are set correctly and all required credential files (SSH keys, datadog & sumologic credentials) are properly provided to `init` & can be downloaded using [behance/docker-aws-s3-downloader](https://github.com/behance/docker-aws-s3-downloader)
+
+#### `init` bootstrap
+
+Our `bootstrap.service` just clones this repo and runs the `init` script.
+
+From there, it does a couple of things:
+
+1. ensure that any credentials/secure files are downloaded from S3 (to allow docker & git to pull private dependencies)
+2. configure SSH configs to allow github.com access
+3. copy `.dockercfg` into `/root` # TODO: refactor process as this is a hack
+4. runs ALL scripts in `v2/setup`
+    - these scripts will always be run with `sudo` (i.e.: as root)
+    - set things up like create motds, aliases, dropins for various services
+5. starts up tier-specific template units that are specified by the running machines' IP (provided by CoreOS / cloudinit)
+    - these are started via fleet, event though they are NOT global units and run on specific machines
+    - rationale for this is to give us granular control over certain units, such as mesos-slaves. It allows us to control individual nodes, or perform rolling actions (such as deploys) while retaining visibility into the cluster as a whole.
+6. submits and starts generic fleet units
+
+#### Docker Image ID etcd keys (under `/images`):
+
+- mesos-master
+- mesos-slave
+- marathon
+- chronos
+- zk
+- capcom (private)
+- capcom2 (private)
+- fd (private)
+
+Set these if you want your units to run different docker containers.
+

--- a/v2/fleet-local/control/flight-director@.service
+++ b/v2/fleet-local/control/flight-director@.service
@@ -7,38 +7,37 @@ Requires=docker.service
 Wants=chronos.service marathon.service
 
 [Service]
-Environment=FD_IMAGE=behance/flight-director:latest
-
+Environment="IMAGE=etcdctl get /images/fd"
 User=core
 Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${FD_IMAGE}
+ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill flight-director
 ExecStartPre=-/usr/bin/docker rm flight-director
 ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
-    --name flight-director \
-    --net='host' \
-    -e LOG_APP_NAME=flight-director \
-    -e FD_API_SERVER_PORT=`etcdctl get /FD/FD_API_SERVER_PORT` \
-    -e FD_CHRONOS_MASTER=`etcdctl get /FD/FD_CHRONOS_MASTER` \
-    -e FD_DB_DATABASE=`etcdctl get /FD/FD_DB_DATABASE` \
-    -e FD_DB_ENGINE=`etcdctl get /FD/FD_DB_ENGINE` \
-    -e FD_DB_PASSWORD=`etcdctl get /FD/FD_DB_PASSWORD` \
-    -e FD_DB_PATH=`etcdctl get /FD/FD_DB_PATH` \
-    -e FD_DB_USERNAME=`etcdctl get /FD/FD_DB_USERNAME` \
-    -e FD_DEBUG=`etcdctl get /FD/FD_DEBUG` \
-    -e FD_DOCKERCFG_LOCATION=`etcdctl get /FD/FD_DOCKERCFG_LOCATION` \
-    -e FD_EVENT_INTERFACE=`etcdctl get /FD/FD_EVENT_INTERFACE` \
-    -e FD_EVENT_PORT=`etcdctl get /FD/FD_EVENT_PORT` \
-    -e FD_FIXTURES=`etcdctl get /FD/FD_FIXTURES` \
-    -e FD_KV_SERVER=`etcdctl get /FD/FD_KV_SERVER` \
-    -e FD_LOG_LEVEL=`etcdctl get /FD/FD_LOG_LEVEL` \
-    -e FD_LOG_LOCATION=`etcdctl get /FD/FD_LOG_LOCATION` \
-    -e FD_LOG_MARATHON_API_CALLS=`etcdctl get /FD/FD_LOG_MARATHON_API_CALLS` \
-    -e FD_MARATHON_MASTER=`etcdctl get /FD/FD_MARATHON_MASTER` \
-    -e FD_MESOS_MASTER=`etcdctl get /FD/FD_MESOS_MASTER` \
-    ${FD_IMAGE}"
+  --name flight-director \
+  --net='host' \
+  -e LOG_APP_NAME=flight-director \
+  -e FD_API_SERVER_PORT=`etcdctl get /FD/FD_API_SERVER_PORT` \
+  -e FD_CHRONOS_MASTER=`etcdctl get /FD/FD_CHRONOS_MASTER` \
+  -e FD_DB_DATABASE=`etcdctl get /FD/FD_DB_DATABASE` \
+  -e FD_DB_ENGINE=`etcdctl get /FD/FD_DB_ENGINE` \
+  -e FD_DB_PASSWORD=`etcdctl get /FD/FD_DB_PASSWORD` \
+  -e FD_DB_PATH=`etcdctl get /FD/FD_DB_PATH` \
+  -e FD_DB_USERNAME=`etcdctl get /FD/FD_DB_USERNAME` \
+  -e FD_DEBUG=`etcdctl get /FD/FD_DEBUG` \
+  -e FD_DOCKERCFG_LOCATION=`etcdctl get /FD/FD_DOCKERCFG_LOCATION` \
+  -e FD_EVENT_INTERFACE=`etcdctl get /FD/FD_EVENT_INTERFACE` \
+  -e FD_EVENT_PORT=`etcdctl get /FD/FD_EVENT_PORT` \
+  -e FD_FIXTURES=`etcdctl get /FD/FD_FIXTURES` \
+  -e FD_KV_SERVER=`etcdctl get /FD/FD_KV_SERVER` \
+  -e FD_LOG_LEVEL=`etcdctl get /FD/FD_LOG_LEVEL` \
+  -e FD_LOG_LOCATION=`etcdctl get /FD/FD_LOG_LOCATION` \
+  -e FD_LOG_MARATHON_API_CALLS=`etcdctl get /FD/FD_LOG_MARATHON_API_CALLS` \
+  -e FD_MARATHON_MASTER=`etcdctl get /FD/FD_MARATHON_MASTER` \
+  -e FD_MESOS_MASTER=`etcdctl get /FD/FD_MESOS_MASTER` \
+  $($IMAGE)"
 ExecStop=/usr/bin/docker stop flight-director
 
 [Install]

--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -5,26 +5,25 @@ Requires=docker.service
 Wants=zookeeper-exhibitor.service
 
 [Service]
-EnvironmentFile=/etc/environment
 Environment=ZOOKEEPER=localhost:2181
-Environment=MARATHON_IMAGE=mesosphere/marathon:v0.10.0
+Environment="IMAGE=etcdctl get /images/marathon"
 
 User=core
 Restart=always
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${MARATHON_IMAGE}
+ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill marathon
 ExecStartPre=-/usr/bin/docker rm marathon
-ExecStart=/usr/bin/docker run \
-    --name marathon \
-    -e LIBPROCESS_PORT=9090 \
-    --net=host \
-    ${MARATHON_IMAGE} \
-    --master zk://${ZOOKEEPER}/mesos \
-    --zk zk://${ZOOKEEPER}/marathon \
-    --checkpoint \
-    --task_launch_timeout 300000
+ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
+  --name marathon \
+  -e LIBPROCESS_PORT=9090 \
+  --net=host \
+  $($IMAGE) \
+  --master zk://${ZOOKEEPER}/mesos \
+  --zk zk://${ZOOKEEPER}/marathon \
+  --checkpoint \
+  --task_launch_timeout 300000"
 ExecStop=/usr/bin/docker stop marathon
 
 [Install]

--- a/v2/fleet-local/control/mesos-master@.service
+++ b/v2/fleet-local/control/mesos-master@.service
@@ -4,29 +4,29 @@ After=docker.service bootstrap.service
 Requires=docker.service bootstrap.service
 
 [Service]
+Environment="IMAGE=etcdctl get /images/mesos-master"
 # ZOOKEEPER_ENDPOINT, NODE_PRODUCT & NODE_TIER should be defined here.
 EnvironmentFile=/etc/environment
-Environment=MESOS_MASTER_IMAGE=mesosphere/mesos-master:0.22.1-1.0.ubuntu1404
 
 User=core
 Restart=always
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${MESOS_MASTER_IMAGE}
+ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_master
 ExecStartPre=-/usr/bin/docker rm mesos_master
 ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
-    --name=mesos_master \
-    --privileged \
-    --net=host \
-    -v /var/lib/mesos/master:/var/lib/mesos/master \
-    ${MESOS_MASTER_IMAGE} \
-    --cluster=$NODE_PRODUCT-$NODE_TIER \
-    --hostname=`curl -s http://169.254.169.254/latest/meta-data/public-hostname` \
-    --log_dir=/var/log/mesos \
-    --quorum=3 \
-    --work_dir=/var/lib/mesos/master \
-    --zk=zk://${ZOOKEEPER_ENDPOINT}/mesos"
+  --name=mesos_master \
+  --privileged \
+  --net=host \
+  -v /var/lib/mesos/master:/var/lib/mesos/master \
+  $($IMAGE) \
+  --cluster=$NODE_PRODUCT-$NODE_TIER \
+  --hostname=`curl -s http://169.254.169.254/latest/meta-data/public-hostname` \
+  --log_dir=/var/log/mesos \
+  --quorum=3 \
+  --work_dir=/var/lib/mesos/master \
+  --zk=zk://${ZOOKEEPER_ENDPOINT}/mesos"
 ExecStop=/usr/bin/docker stop mesos_master
 
 [Install]

--- a/v2/fleet-local/control/zk-exhibitor@.service
+++ b/v2/fleet-local/control/zk-exhibitor@.service
@@ -4,25 +4,25 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment=EXHIBITOR_IMAGE=behance/exhibitor:latest
+Environment="IMAGE=etcdctl get /images/zk-exhibitor"
 
 User=core
 Restart=always
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${EXHIBITOR_IMAGE}
+ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill zookeeper-exhibitor
 ExecStartPre=-/usr/bin/docker rm zookeeper-exhibitor
 ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
-          --name=zookeeper-exhibitor \
-          -p 8181:8181 -p 2181:2181 -p 2888:2888 -p 3888:3888 \
-          -v /opt/zookeeper/transactions:/opt/zookeeper/transactions \
-          -v /opt/zookeeper/snapshots:/opt/zookeeper/snapshots \
-          -e S3_BUCKET=`etcdctl get /zookeeper/s3_exhibitor_bucket` \
-          -e S3_PREFIX=`etcdctl get /zookeeper/s3_exhibitor_prefix` \
-          -e AWS_REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region` \
-          -e HOSTNAME=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4` \
-          ${EXHIBITOR_IMAGE}"
+  --name=zookeeper-exhibitor \
+  -p 8181:8181 -p 2181:2181 -p 2888:2888 -p 3888:3888 \
+  -v /opt/zookeeper/transactions:/opt/zookeeper/transactions \
+  -v /opt/zookeeper/snapshots:/opt/zookeeper/snapshots \
+  -e S3_BUCKET=`etcdctl get /zookeeper/s3_exhibitor_bucket` \
+  -e S3_PREFIX=`etcdctl get /zookeeper/s3_exhibitor_prefix` \
+  -e AWS_REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region` \
+  -e HOSTNAME=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4` \
+  $($IMAGE)"
 ExecStop=/usr/bin/docker stop zookeeper-exhibitor
 
 [Install]

--- a/v2/fleet-local/proxy/capcom@.service
+++ b/v2/fleet-local/proxy/capcom@.service
@@ -4,17 +4,17 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment=CP_IMAGE=behance/capcom:latest
-
 User=core
 Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${CP_IMAGE}
+Environment="IMAGE=etcdctl get /images/capcom"
+ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill capcom
 ExecStartPre=-/usr/bin/docker rm capcom
 # NOTE: it's critical to source the etcdctl.sh file so that etcd connects to the correct cluster.
-ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && /usr/bin/docker run \
+ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
+  docker run \
     --name capcom \
     --net='host' \
     --privileged \
@@ -32,7 +32,7 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && /usr/bin/docker ru
     -e CP_PROXY_ENABLED=`etcdctl get /CP/CP_PROXY_ENABLED` \
     -e CP_PROXY_RESTART_SCRIPT=`etcdctl get /CP/CP_PROXY_RESTART_SCRIPT` \
     -e CP_PROXY_TIMEOUT=`etcdctl get /CP/CP_PROXY_TIMEOUT` \
-    ${CP_IMAGE}"
+    $($IMAGE)"
 ExecStop=/usr/bin/docker stop capcom
 
 [Install]

--- a/v2/fleet-local/worker/mesos-slave@.service
+++ b/v2/fleet-local/worker/mesos-slave@.service
@@ -4,18 +4,21 @@ After=docker.service bootstrap.service
 Requires=docker.service bootstrap.service
 
 [Service]
-# ZOOKEEPER_ENDPOINT should be defined here.
+Environment="IMAGE=etcdctl get /images/mesos-slave"
+# ZOOKEEPER_ENDPOINT & ETCDCTL_PEERS_ENDPOINT should be defined here.
 EnvironmentFile=/etc/environment
-Environment=MESOS_SLAVE_IMAGE=mesosphere/mesos-slave:0.22.1-1.0.ubuntu1404
 
 User=core
 Restart=always
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${MESOS_SLAVE_IMAGE}
+
+ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_slave
 ExecStartPre=-/usr/bin/docker rm mesos_slave
-ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
+
+ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
+  sudo docker run \
     --name=mesos_slave \
     --net=host \
     --pid=host \
@@ -26,7 +29,7 @@ ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /lib64/libdevmapper.so.1.02:/lib/libdevmapper.so.1.02:ro \
     -v /var/lib/mesos/slave:/var/lib/mesos/slave \
-    ${MESOS_SLAVE_IMAGE} \
+    $($IMAGE) \
     --ip=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4` \
     --attributes=zone:$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)\;os:coreos \
     --containerizers=docker,mesos \
@@ -35,10 +38,10 @@ ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
     --log_dir=/var/log/mesos \
     --master=zk://${ZOOKEEPER_ENDPOINT}/mesos \
     --work_dir=/var/lib/mesos/slave"
-ExecStop=/usr/bin/docker stop mesos_slave
 ExecStartPost=/usr/bin/docker pull behance/utility:latest
 ExecStartPost=/usr/bin/docker pull ubuntu:14.04
 ExecStartPost=/usr/bin/docker pull debian:jessie
+ExecStop=/usr/bin/docker stop mesos_slave
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-manual/capcom2@.service
+++ b/v2/fleet-manual/capcom2@.service
@@ -4,17 +4,17 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment=CP_IMAGE=behance/capcom:latest
-
 User=core
 Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${CP_IMAGE}
+Environment="IMAGE=etcdctl get /images/capcom2"
+ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill capcom2
 ExecStartPre=-/usr/bin/docker rm capcom2
 # NOTE: it's critical to source the etcdctl.sh file so that etcd connects to the correct cluster.
-ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && /usr/bin/docker run \
+ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
+  docker run \
     --name capcom2 \
     --net='host' \
     --privileged \
@@ -32,7 +32,7 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && /usr/bin/docker ru
     -e CP_PROXY_ENABLED=`etcdctl get /CP/CP_PROXY_ENABLED` \
     -e CP_PROXY_RESTART_SCRIPT=`etcdctl get /CP/CP_PROXY_RESTART_SCRIPT` \
     -e CP_PROXY_TIMEOUT=`etcdctl get /CP/CP_PROXY_TIMEOUT` \
-    ${CP_IMAGE}"
+    $($IMAGE)"
 ExecStop=/usr/bin/docker stop capcom2
 
 [Install]

--- a/v2/fleet-manual/chronos@.service
+++ b/v2/fleet-manual/chronos@.service
@@ -5,30 +5,29 @@ After=docker.service mesos-master.service marathon.service
 Requires=docker.service
 
 [Service]
-EnvironmentFile=/etc/environment
 # NOTE: chronos doesn't need the `zk://`
 Environment=ZOOKEEPER=localhost:2181
-Environment=CHRONOS_IMAGE=mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.23.0-1.0.ubuntu1404
+Environment="IMAGE=etcdctl get /images/chronos"
 
 User=core
 Restart=always
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull ${CHRONOS_IMAGE}
+ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill chronos
 ExecStartPre=-/usr/bin/docker rm chronos
-ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
-    --name chronos \
-    --net=host \
-    --env LIBPROCESS_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4` \
-    --env LIBPROCESS_PORT=4401 \
-    ${CHRONOS_IMAGE} \
-    /usr/bin/chronos \
-    run_jar \
-    --http_port 4400 \
-    --master zk://${ZOOKEEPER}/mesos \
-    --mesos_framework_name chronos-`hostname` \
-    --zk_hosts ${ZOOKEEPER}"
+ExecStart=/usr/bin/sh -c "docker run \
+  --name chronos \
+  --net=host \
+  --env LIBPROCESS_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4` \
+  --env LIBPROCESS_PORT=4401 \
+  $($IMAGE) \
+  /usr/bin/chronos \
+  run_jar \
+  --http_port 4400 \
+  --master zk://${ZOOKEEPER}/mesos \
+  --mesos_framework_name chronos-`hostname` \
+  --zk_hosts ${ZOOKEEPER}"
 
 ExecStop=/usr/bin/docker stop chronos
 

--- a/v2/setup/image-ids.sh
+++ b/v2/setup/image-ids.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source /etc/environment
+export ETCDCTL_PEERS="http://$ETCDCTL_PEERS_ENDPOINT"
+
+etcdctl set /images/capcom       "behance/capcom:latest"
+etcdctl set /images/capcom2      "behance/capcom:latest"
+etcdctl set /images/chronos      "mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.23.0-1.0.ubuntu1404"
+etcdctl set /images/fd           "behance/flight-director:latest"
+etcdctl set /images/marathon     "mesosphere/marathon:v0.10.0"
+etcdctl set /images/mesos-master "mesosphere/mesos-master:0.22.1-1.0.ubuntu1404"
+etcdctl set /images/mesos-slave  "mesosphere/mesos-slave:0.22.1-1.0.ubuntu1404"
+etcdctl set /images/zk-exhibitor "behance/exhibitor:latest"


### PR DESCRIPTION
- search etcdctl for image ids, use them
- fallbacks are defined in unit files

You will see weird things in this PR:
- there are Environment variables that are in the form of `Environment="IMAGE=etcdctl get /images/marathon"`
- said environment variables are expanded via `/usr/bin/bash -c ".... $($IMAGE) ...."`

Reason for this is so that we can have a common variable to reference `$IMAGE`. However, since it is a bash command and I do not want to copy & paste it in multiple places (once for the `ExecStartPre` pull, another for the actual docker run command), it is in the form of a systemd environment variable.

So what `$($IMAGE)` is doing is:
1. forcing systemd to expand `$IMAGE` as the command
2. delegating the execution of the command to a bash runtime.
