### PR TITLE
Docker-Cleanup automation tweaks

### DIFF
--- a/v2/fleet/docker-cleanup.service
+++ b/v2/fleet/docker-cleanup.service
@@ -4,8 +4,6 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment=MAX_DOCKER=25
-
 User=core
 Restart=on-failure
 RestartSec=20

--- a/v2/fleet/docker-cleanup.service
+++ b/v2/fleet/docker-cleanup.service
@@ -17,4 +17,3 @@ https://raw.githubusercontent.com/behance/mesos-systemd/master/v2/util/docker-cl
 [X-Fleet]
 Global=true
 MachineMetadata=role=worker
-MachineMetadata=role=proxy

--- a/v2/fleet/docker-cleanup.service
+++ b/v2/fleet/docker-cleanup.service
@@ -10,9 +10,7 @@ User=core
 Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
-ExecStart=/usr/bin/bash -c '/usr/bin/wget -O /home/core/docker-cleanup.sh \
-https://raw.githubusercontent.com/behance/mesos-systemd/master/v2/util/docker-cleanup.sh \
-&& /usr/bin/bash /home/core/docker-cleanup.sh'
+ExecStart=/usr/bin/sudo bash /home/core/mesos-systemd/v2/util/docker-cleanup.sh
 
 [X-Fleet]
 Global=true

--- a/v2/fleet/docker-cleanup.timer
+++ b/v2/fleet/docker-cleanup.timer
@@ -16,4 +16,3 @@ OnUnitActiveSec=4h
 [X-Fleet]
 Global=true
 MachineMetadata=role=worker
-MachineMetadata=role=proxy


### PR DESCRIPTION
- only run on worker nodes
- remove exited containers & volumes, per usual
- do a basic run-through of `docker rmi` (not `--force` so that running containers stay running)
- audit `/var/lib/docker/$FSDRIVER`, cross-reference with daemon and delete
