### PR TITLE
zk-health.service to block locksmithd, hardening unit dependencies

### DIFF
--- a/v2/fleet-local/control/flight-director@.service
+++ b/v2/fleet-local/control/flight-director@.service
@@ -2,9 +2,9 @@
 Description=Flight Director @ %i
 # it's implied that chronos & marathon require mesos
 # look here: https://github.com/behance/mesos-systemd/tree/master/v2/fleet
-After=docker.service chronos.service marathon.service
+After=docker.service chronos@%i.service marathon@%i.service
 Requires=docker.service
-Wants=chronos.service marathon.service
+Wants=chronos@%i.service marathon@%i.service
 
 [Service]
 Environment="IMAGE=etcdctl get /images/fd"

--- a/v2/fleet-local/control/flight-director@.service
+++ b/v2/fleet-local/control/flight-director@.service
@@ -10,8 +10,10 @@ Wants=chronos@%i.service marathon@%i.service
 Environment="IMAGE=etcdctl get /images/fd"
 User=core
 Restart=on-failure
-RestartSec=20
+RestartSec=8
 TimeoutStartSec=0
+
+ExecStartPre=/usr/bin/systemctl is-active marathon@%i.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill flight-director
 ExecStartPre=-/usr/bin/docker rm flight-director

--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Marathon @ %i
 Requires=docker.service
-After=docker.service bootstrap.service zk-health@%i.service
-Wants=zk-health@%i.service
+After=docker.service bootstrap.service zk-health.service mesos-master@%i.service
 
 [Service]
 Environment=ZOOKEEPER=localhost:2181
@@ -13,7 +12,7 @@ Restart=always
 RestartSec=8
 TimeoutStartSec=0
 
-ExecStartPre=/usr/bin/systemctl is-active zk-health@%i.service
+ExecStartPre=/usr/bin/systemctl is-active zk-health.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill marathon
 ExecStartPre=-/usr/bin/docker rm marathon

--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -13,6 +13,7 @@ RestartSec=8
 TimeoutStartSec=0
 
 ExecStartPre=/usr/bin/systemctl is-active zk-health.service
+ExecStartPre=/usr/bin/systemctl is-active mesos-master@*
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill marathon
 ExecStartPre=-/usr/bin/docker rm marathon

--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Marathon @ %i
-After=docker.service zookeeper-exhibitor.service mesos-master.service
 Requires=docker.service
-Wants=zookeeper-exhibitor.service
+After=docker.service bootstrap.service zk-health@%i.service
 
 [Service]
 Environment=ZOOKEEPER=localhost:2181

--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -2,6 +2,7 @@
 Description=Marathon @ %i
 Requires=docker.service
 After=docker.service bootstrap.service zk-health@%i.service
+Wants=zk-health@%i.service
 
 [Service]
 Environment=ZOOKEEPER=localhost:2181
@@ -9,8 +10,10 @@ Environment="IMAGE=etcdctl get /images/marathon"
 
 User=core
 Restart=always
-RestartSec=20
+RestartSec=8
 TimeoutStartSec=0
+
+ExecStartPre=/usr/bin/systemctl is-active zk-health@%i.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill marathon
 ExecStartPre=-/usr/bin/docker rm marathon

--- a/v2/fleet-local/control/mesos-master@.service
+++ b/v2/fleet-local/control/mesos-master@.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=MesosMaster @ %i
 Requires=docker.service
-After=docker.service bootstrap.service zk-health@%i.service
-Wants=zk-health@%i.service
+After=docker.service bootstrap.service zk-health.service
 
 [Service]
 Environment="IMAGE=etcdctl get /images/mesos-master"
@@ -14,7 +13,7 @@ Restart=always
 RestartSec=8
 TimeoutStartSec=0
 
-ExecStartPre=/usr/bin/systemctl is-active zk-health@%i.service
+ExecStartPre=/usr/bin/systemctl is-active zk-health.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_master
 ExecStartPre=-/usr/bin/docker rm mesos_master

--- a/v2/fleet-local/control/mesos-master@.service
+++ b/v2/fleet-local/control/mesos-master@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=MesosMaster @ %i
-After=docker.service bootstrap.service
-Requires=docker.service bootstrap.service
+Requires=docker.service
+After=docker.service bootstrap.service zk-health@%i.service
 
 [Service]
 Environment="IMAGE=etcdctl get /images/mesos-master"

--- a/v2/fleet-local/control/mesos-master@.service
+++ b/v2/fleet-local/control/mesos-master@.service
@@ -2,6 +2,7 @@
 Description=MesosMaster @ %i
 Requires=docker.service
 After=docker.service bootstrap.service zk-health@%i.service
+Wants=zk-health@%i.service
 
 [Service]
 Environment="IMAGE=etcdctl get /images/mesos-master"
@@ -10,8 +11,10 @@ EnvironmentFile=/etc/environment
 
 User=core
 Restart=always
-RestartSec=20
+RestartSec=8
 TimeoutStartSec=0
+
+ExecStartPre=/usr/bin/systemctl is-active zk-health@%i.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_master
 ExecStartPre=-/usr/bin/docker rm mesos_master

--- a/v2/fleet-local/control/zk-exhibitor@.service
+++ b/v2/fleet-local/control/zk-exhibitor@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Exhibitor/Zookeeper @ %i
+Before=zk-health@%i.service
 After=docker.service
 Requires=docker.service
 

--- a/v2/fleet-local/control/zk-exhibitor@.service
+++ b/v2/fleet-local/control/zk-exhibitor@.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Exhibitor/Zookeeper @ %i
-Before=zk-health@%i.service
 After=docker.service
 Requires=docker.service
+Before=zk-health.service
+Wants=zk-health.service
 
 [Service]
 Environment="IMAGE=etcdctl get /images/zk-exhibitor"

--- a/v2/fleet-local/control/zk-health@.service
+++ b/v2/fleet-local/control/zk-health@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Exhibitor/Zookeeper health checker/block @ %i
+
+# forces things like the update-engine (and related services such as managed
+# CoreOS) to wait for this unit to complete
+Before=locksmithd.service marathon@%i.service mesos-master@%i.service
+After=zk-exhibitor@%i.service
+
+[Service]
+Type=simple
+User=core
+Restart=on-failure
+RemainAfterExit=true
+
+# array of objects, each representing a ZK node
+Environment="EX_QUERY=curl -sS localhost:8181/exhibitor/v1/cluster/status"
+# expected size of ensemble after it's done
+Environment="CTL_SIZE=etcdctl get /environment/CONTROL_CLUSTER_SIZE"
+
+# wait for zk-exhibitor to start - can't use %i specifier here
+ExecStartPre=/usr/bin/bash -c 'while [ "$(systemctl is-active zk-exhibitor@*)" != "active" ]; do sleep 2; done'
+# code==3 means that the node is up and serving
+ExecStartPre=/usr/bin/bash -c 'while [ $($EX_QUERY|jq "[select(.[].code == 3)]|length") != $($CTL_SIZE) ]; do sleep 4; done'
+
+ExecStart=/usr/bin/sleep infinity
+
+[Install]
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=true
+MachineMetadata=role=control
+MachineMetadata=ip=%i

--- a/v2/fleet-local/control/zk-health@.service
+++ b/v2/fleet-local/control/zk-health@.service
@@ -5,6 +5,7 @@ Description=Exhibitor/Zookeeper health checker/block @ %i
 # CoreOS) to wait for this unit to complete
 Before=locksmithd.service marathon@%i.service mesos-master@%i.service
 After=zk-exhibitor@%i.service
+Requires=zk-exhibitor@%i.service
 
 [Service]
 Type=simple

--- a/v2/fleet-manual/chronos@.service
+++ b/v2/fleet-manual/chronos@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Chronos @ %i
 # implied here that marathon requires mesos-master
-After=docker.service mesos-master.service marathon.service
+After=docker.service mesos-master@%i.service marathon@%i.service
 Requires=docker.service
 
 [Service]

--- a/v2/fleet/fd-hud.service
+++ b/v2/fleet/fd-hud.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=HUD for flight-director
 Requires=docker.service
-After=docker.service flight-director@*.service
+After=docker.service
 
 [Service]
 User=core
@@ -11,7 +11,7 @@ RestartSec=4
 TimeoutStartSec=0
 Environment="IMAGE=etcdctl get /images/hud"
 
-ExecStartPre=/usr/bin/systemctl is-active flight-director@*.service
+ExecStartPre=/usr/bin/systemctl is-active flight-director@*
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill fd-hud
 ExecStartPre=-/usr/bin/docker rm fd-hud

--- a/v2/fleet/fd-hud.service
+++ b/v2/fleet/fd-hud.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=HUD for flight-director
 Requires=docker.service
-After=docker.service
+After=docker.service flight-director@*.service
 
 [Service]
 User=core
@@ -10,6 +10,8 @@ Restart=always
 RestartSec=4
 TimeoutStartSec=0
 Environment="IMAGE=etcdctl get /images/hud"
+
+ExecStartPre=/usr/bin/systemctl is-active flight-director@*.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill fd-hud
 ExecStartPre=-/usr/bin/docker rm fd-hud

--- a/v2/setup/zookeeper.sh
+++ b/v2/setup/zookeeper.sh
@@ -9,3 +9,7 @@ fi
 etcdctl set /zookeeper/s3_exhibitor_prefix "zk"
 etcdctl set /zookeeper/s3_exhibitor_bucket $EXHIBITOR_S3BUCKET
 etcdctl set /zookeeper/ensemble_size $CONTROL_CLUSTER_SIZE
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+sudo cp $SCRIPTDIR/../util-units/zk-health.service /etc/systemd/system/zk-health.service
+sudo systemctl daemon-reload

--- a/v2/util-units/zk-health.service
+++ b/v2/util-units/zk-health.service
@@ -1,25 +1,22 @@
 [Unit]
-Description=Exhibitor/Zookeeper health checker/block @ %i
+Description=Exhibitor/Zookeeper health checker
 
 # forces things like the update-engine (and related services such as managed
 # CoreOS) to wait for this unit to complete
-Before=locksmithd.service marathon@%i.service mesos-master@%i.service
-After=zk-exhibitor@%i.service
-Requires=zk-exhibitor@%i.service
+Before=locksmithd.service
 
 [Service]
 Type=simple
 User=core
 Restart=on-failure
-RemainAfterExit=true
 
 # array of objects, each representing a ZK node
 Environment="EX_QUERY=curl -sS localhost:8181/exhibitor/v1/cluster/status"
 # expected size of ensemble after it's done
 Environment="CTL_SIZE=etcdctl get /environment/CONTROL_CLUSTER_SIZE"
 
-# wait for zk-exhibitor to start - can't use %i specifier here
 ExecStartPre=/usr/bin/bash -c 'while [ "$(systemctl is-active zk-exhibitor@*)" != "active" ]; do sleep 2; done'
+ExecStartPre=/usr/bin/sleep 16
 # code==3 means that the node is up and serving
 ExecStartPre=/usr/bin/bash -c 'while [ $($EX_QUERY|jq "[select(.[].code == 3)]|length") != $($CTL_SIZE) ]; do sleep 4; done'
 
@@ -27,8 +24,3 @@ ExecStart=/usr/bin/sleep infinity
 
 [Install]
 WantedBy=multi-user.target
-
-[X-Fleet]
-Global=true
-MachineMetadata=role=control
-MachineMetadata=ip=%i


### PR DESCRIPTION
- block `locksmithd` startup based on `/v1/exhibitor/cluster/status`
- have marathon & mesos services wait for `zk-health.service` to complete before starting

Note that these changes only affects unit **startup**. On purpose, I omitted using `PartOf=` & `BindsTo=` relations. This way, if things like `zk-health` disappears all of a sudden the `stop` or `restart` actions do not cascade down to child units. However, we might want to evaluate those at some point in time.
### On initial boot/startup

Before zk-exhibitor has started & have all `etcdctl get /zookeeper/ensemble_size` nodes serving:
![screen shot 2015-10-09 at 2 46 53 pm](https://cloud.githubusercontent.com/assets/1102319/10402672/c6ebe17c-6e94-11e5-9d71-58c41355ba39.jpg)

After all ZK members start serving:
![screen shot 2015-10-09 at 2 51 03 pm](https://cloud.githubusercontent.com/assets/1102319/10402724/09fdd132-6e95-11e5-9601-c59580ac09a0.jpg)
### on reboot

before everything starts running
![screen shot 2015-10-09 at 2 55 54 pm](https://cloud.githubusercontent.com/assets/1102319/10402885/fdb7fd34-6e95-11e5-8f2a-0518d24084b1.jpg)

after ZK joins the ensemble. Note that locksmithd starts up (timestamps indicate this)
![screen shot 2015-10-09 at 2 57 14 pm](https://cloud.githubusercontent.com/assets/1102319/10402897/0bf051b2-6e96-11e5-8127-29e66558cbc0.jpg)
