### PR TITLE
fleet-local/control: cfn-signal

### DIFF
--- a/v2/fleet-local/control/cfn-signal@.service
+++ b/v2/fleet-local/control/cfn-signal@.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=CFN Signaler @ %i
+Requires=docker.service
+After=docker.service bootstrap.service
+After=zk-health.service mesos-master@%i.service marathon@%i.service
+
+[Service]
+EnvironmentFile=/etc/environment
+Environment="IMAGE=etcdctl get /images/cfn-signal"
+Environment="AZ=curl -sS http://169.254.169.254/latest/meta-data/placement/availability-zone"
+Type=simple
+User=core
+Restart=on-failure
+
+ExecStartPre=/usr/bin/systemctl is-active zk-health.service
+ExecStartPre=/usr/bin/systemctl is-active mesos-master@*
+ExecStartPre=/usr/bin/systemctl is-active marathon@*
+ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
+ExecStartPre=/usr/bin/sh -c "/usr/bin/docker run\
+ $($IMAGE) cfn-signal\
+ --stack $STACK_NAME\
+ --region $($AZ|head -c-1)\
+ --resource $CONTROL_ASG_NAME\
+ --success true"
+
+ExecStart=/usr/bin/sleep infinity
+
+[Install]
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=false
+MachineMetadata=role=control
+MachineMetadata=ip=%i

--- a/v2/setup/images-control.sh
+++ b/v2/setup/images-control.sh
@@ -12,6 +12,7 @@ etcdctl set /images/hud          "behance/flight-director-hud:latest"
 etcdctl set /images/marathon     "mesosphere/marathon:v0.10.0"
 etcdctl set /images/mesos-master "mesosphere/mesos-master:0.22.1-1.0.ubuntu1404"
 etcdctl set /images/zk-exhibitor "behance/docker-zk-exhibitor:latest"
+etcdctl set /images/cfn-signal   "behance/docker-cfn-bootstrap:latest"
 
 # pull down images serially to avoid a FS layer clobbering bug in docker 1.6.x
 docker pull jenkins
@@ -22,3 +23,4 @@ docker pull $(etcdctl get /images/hud)
 docker pull $(etcdctl get /images/marathon)
 docker pull $(etcdctl get /images/mesos-master)
 docker pull $(etcdctl get /images/zk-exhibitor)
+docker pull $(etcdctl get /images/cfn-signal)


### PR DESCRIPTION
Seems to only happen with rolling updates...? Not when the stack first gets spun up.
Requires updates in the templates to allow EC2 instances to use `SignalResource` (IAM & policy)
