### PR TITLE
operation stability tweaks

### DIFF
--- a/v2/fleet-local/control/flight-director@.service
+++ b/v2/fleet-local/control/flight-director@.service
@@ -46,7 +46,9 @@ ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   -e GITHUB_CLIENT_SECRET=`etcdctl get /FD/GITHUB_CLIENT_SECRET` \
   -e AUTHORIZER_TYPE=`etcdctl get /FD/AUTHORIZER_TYPE` \
   $($IMAGE)"
-ExecStop=/usr/bin/docker stop flight-director
+
+ExecStop=-/usr/bin/docker stop flight-director
+ExecStop=/usr/bin/fleetctl destroy flight-director@%i
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -17,6 +17,7 @@ ExecStartPre=/usr/bin/systemctl is-active mesos-master@*
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill marathon
 ExecStartPre=-/usr/bin/docker rm marathon
+
 ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   --name marathon \
   -e LIBPROCESS_PORT=9090 \
@@ -26,7 +27,9 @@ ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   --zk zk://${ZOOKEEPER}/marathon \
   --checkpoint \
   --task_launch_timeout 300000"
-ExecStop=/usr/bin/docker stop marathon
+
+ExecStop=-/usr/bin/docker stop marathon
+ExecStop=/usr/bin/fleetctl destroy marathon@%i
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-local/control/mesos-master@.service
+++ b/v2/fleet-local/control/mesos-master@.service
@@ -17,6 +17,7 @@ ExecStartPre=/usr/bin/systemctl is-active zk-health.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_master
 ExecStartPre=-/usr/bin/docker rm mesos_master
+
 ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
   --name=mesos_master \
   --privileged \
@@ -29,7 +30,9 @@ ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
   --quorum=3 \
   --work_dir=/var/lib/mesos/master \
   --zk=zk://`etcdctl get /environment/ZOOKEEPER_ENDPOINT`/mesos"
-ExecStop=/usr/bin/docker stop mesos_master
+
+ExecStop=-/usr/bin/docker stop mesos_master
+ExecStop=/usr/bin/fleetctl destroy mesos-master@%i
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-local/control/zk-exhibitor@.service
+++ b/v2/fleet-local/control/zk-exhibitor@.service
@@ -12,9 +12,11 @@ User=core
 Restart=always
 RestartSec=20
 TimeoutStartSec=0
+
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill zookeeper-exhibitor
 ExecStartPre=-/usr/bin/docker rm zookeeper-exhibitor
+
 ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
   --name=zookeeper-exhibitor \
   -p 8181:8181 -p 2181:2181 -p 2888:2888 -p 3888:3888 \
@@ -26,7 +28,9 @@ ExecStart=/usr/bin/sh -c "sudo /usr/bin/docker run \
   -e AWS_REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region` \
   -e HOSTNAME=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4` \
   $($IMAGE)"
-ExecStop=/usr/bin/docker stop zookeeper-exhibitor
+
+ExecStop=-/usr/bin/docker stop zookeeper-exhibitor
+ExecStop=/usr/bin/fleetctl destroy zk-exhibitor@%i
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-local/proxy/capcom@.service
+++ b/v2/fleet-local/proxy/capcom@.service
@@ -9,9 +9,11 @@ Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
 Environment="IMAGE=etcdctl get /images/capcom"
+
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill capcom
 ExecStartPre=-/usr/bin/docker rm capcom
+
 # NOTE: it's critical to source the etcdctl.sh file so that etcd connects to the correct cluster.
 ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
   docker run \
@@ -33,7 +35,9 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
     -e CP_PROXY_RESTART_SCRIPT=`etcdctl get /CP/CP_PROXY_RESTART_SCRIPT` \
     -e CP_PROXY_TIMEOUT=`etcdctl get /CP/CP_PROXY_TIMEOUT` \
     $($IMAGE)"
-ExecStop=/usr/bin/docker stop capcom
+
+ExecStop=-/usr/bin/docker stop capcom
+ExecStop=/usr/bin/fleetctl destroy capcom@%i
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-local/worker/mesos-slave@.service
+++ b/v2/fleet-local/worker/mesos-slave@.service
@@ -11,6 +11,9 @@ Restart=always
 RestartSec=20
 TimeoutStartSec=0
 
+# condition / assertion options here for some reason do not prevent the ExecStart from spinning up
+# and mounting / creating .dockercfg/ as a dir
+ExecStartPre=/usr/bin/bash -c "if [ ! -f /home/core/.dockercfg ]; then exit 1; fi"
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_slave
 ExecStartPre=-/usr/bin/docker rm mesos_slave

--- a/v2/fleet-local/worker/mesos-slave@.service
+++ b/v2/fleet-local/worker/mesos-slave@.service
@@ -39,7 +39,9 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
     --log_dir=/var/log/mesos \
     --master=zk://`etcdctl get /environment/ZOOKEEPER_ENDPOINT`/mesos \
     --work_dir=/var/lib/mesos/slave"
-ExecStop=/usr/bin/docker stop mesos_slave
+
+ExecStop=-/usr/bin/docker stop mesos_slave
+ExecStop=/usr/bin/fleetctl destroy mesos-slave@%i
 
 [Install]
 WantedBy=multi-user.target

--- a/v2/fleet-local/worker/mesos-slave@.service
+++ b/v2/fleet-local/worker/mesos-slave@.service
@@ -36,9 +36,6 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
     --log_dir=/var/log/mesos \
     --master=zk://`etcdctl get /environment/ZOOKEEPER_ENDPOINT`/mesos \
     --work_dir=/var/lib/mesos/slave"
-ExecStartPost=/usr/bin/docker pull behance/utility:latest
-ExecStartPost=/usr/bin/docker pull ubuntu:14.04
-ExecStartPost=/usr/bin/docker pull debian:jessie
 ExecStop=/usr/bin/docker stop mesos_slave
 
 [Install]


### PR DESCRIPTION
- `ExecStop` commands that perform `docker stop` are allowed to fail (not all apps can be stopped cleanly)
- mesos-slave@ has an explicit check for the existence of `/home/core/.dockercfg` as a file
- template unit files remove themselves using an `ExecStop` option & the specifier
