### PR TITLE
[WIP] fleet/datadog: mount docker runtime

### DIFF
--- a/v2/fleet/datadog.service
+++ b/v2/fleet/datadog.service
@@ -14,12 +14,21 @@ ExecStartPre=/usr/bin/docker pull behance/docker-dd-agent:latest
 ExecStartPre=-/usr/bin/docker kill dd-agent
 ExecStartPre=-/usr/bin/docker rm -f dd-agent
 ExecStart=/usr/bin/bash -c \
-"if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent -h `hostname` \
--v /var/run/docker.sock:/var/run/docker.sock \
--v /proc/:/host/proc/:ro \
--v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
--e API_KEY=`etcdctl get /ddapikey` \
-behance/docker-dd-agent"
+"if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
+sudo /usr/bin/docker run \
+  --privileged \
+  --name dd-agent \
+  -h `hostname` \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /proc/:/host/proc/:ro \
+  -v /sys:/sys:ro \
+  -v /usr/bin/docker:/usr/bin/docker:ro \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /lib64/libdevmapper.so:/lib/libdevmapper.so.1.02:ro \
+  -v /lib64/libsystemd.so:/lib/libsystemd.so.0:ro \
+  -v /lib64/libgcrypt.so:/lib/libgcrypt.so.20:ro \
+  -e API_KEY=`etcdctl get /ddapikey` \
+  behance/docker-dd-agent"
 ExecStop=/usr/bin/docker stop dd-agent
 
 [X-Fleet]


### PR DESCRIPTION
Allows things like `docker ps -a` to be run within the container.

Enables https://github.com/behance/docker-dd-agent/tree/daemon-check (`behance/docker-dd-agent:daemon-check` image).

![screen shot 2016-02-08 at 5 24 54 pm](https://cloud.githubusercontent.com/assets/1102319/12901302/e6f1c7b2-ce88-11e5-8479-f8ddf4deacd9.jpg)
