### PR TITLE
Force Update CoreOS on boot.

### DIFF
--- a/v2/fleet-local/control/marathon@.service
+++ b/v2/fleet-local/control/marathon@.service
@@ -14,6 +14,7 @@ Restart=always
 RestartSec=8
 TimeoutStartSec=0
 
+ExecStartPre=/usr/bin/systemctl is-active update-os.service
 ExecStartPre=/usr/bin/systemctl is-active zk-health.service
 ExecStartPre=/usr/bin/systemctl is-active mesos-master@*
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"

--- a/v2/fleet-local/control/mesos-master@.service
+++ b/v2/fleet-local/control/mesos-master@.service
@@ -13,6 +13,7 @@ Restart=always
 RestartSec=8
 TimeoutStartSec=0
 
+ExecStartPre=/usr/bin/systemctl is-active update-os.service
 ExecStartPre=/usr/bin/systemctl is-active zk-health.service
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_master

--- a/v2/fleet-local/worker/mesos-slave@.service
+++ b/v2/fleet-local/worker/mesos-slave@.service
@@ -12,8 +12,9 @@ Restart=always
 RestartSec=20
 TimeoutStartSec=0
 
-# condition / assertion options here for some reason do not prevent the ExecStart from spinning up
-# and mounting / creating .dockercfg/ as a dir
+ExecStartPre=/usr/bin/systemctl is-active update-os.service
+# condition / assertion options here for some reason do not prevent the
+# ExecStart from spinning up and mounting / creating .dockercfg/ as a dir
 ExecStartPre=/usr/bin/bash -c "if [ ! -f /home/core/.dockercfg ]; then exit 1; fi"
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill mesos_slave

--- a/v2/fleet/update-os.service
+++ b/v2/fleet/update-os.service
@@ -1,0 +1,16 @@
+# Force update CoreOS. Should not affect clusters that are being spun up, unless the AMI is
+# out of date...in which case the machines will reboot.
+# Primarily for machines that are just coming up with an older version of CoreOS. As soon as
+# they come up this fleet unit will be launched on them, forcing a reboot.
+[Unit]
+Description=Force update CoreOS
+
+[Service]
+Type=oneshot
+SuccessExitStatus=0 1
+RemainAfterExit=yes
+
+ExecStart=/usr/bin/bash -c "update_engine_client -update|grep NEED_REBOOT && shutdown -r"
+
+[X-Fleet]
+Global=true


### PR DESCRIPTION
- `update-os` fleet unit to force system OS update & reboot
- when there are no updates or if `update_engine_client` fails to `-update`, the unit just stays active instead of rebooting the system.
- mesos & marathon units require the `update-os` unit to be up & running.
- on cluster creation, this may cause failures as a system reboot will stall out mesos & marathon form starting up, and consequently, `zk-health`; ultimately, this will FORCE us to correctly update AMIs on cluster creation
- because this is a fleet unit, new nodes that are spinning up will automatically have this run. While it's running, that should prevent mesos & marathon from running too.

**NOTE**: this does NOT account for connectivity issues between the node & the update channel/provider
