### PR TITLE
Adding default blank SSL setting for Capcom

### DIFF
--- a/v2/setup/capcom.sh
+++ b/v2/setup/capcom.sh
@@ -29,6 +29,7 @@ etcdctl set /CP/CP_PROXY_ENABLED true
 etcdctl set /CP/CP_PROXY_RESTART_SCRIPT /restart_nginx_docker.sh
 etcdctl set /CP/CP_PROXY_TIMEOUT 60000
 etcdctl set /CP/CP_PROXY_DOCKER_COMMAND "nginx -g 'daemon off;'"
+etcdctl set /CP/CP_SSL_CERT_LOCATION ""
 
 HOMEDIR=$(eval echo "~`whoami`")
 

--- a/v2/setup/capcom.sh
+++ b/v2/setup/capcom.sh
@@ -29,7 +29,6 @@ etcdctl set /CP/CP_PROXY_ENABLED true
 etcdctl set /CP/CP_PROXY_RESTART_SCRIPT /restart_nginx_docker.sh
 etcdctl set /CP/CP_PROXY_TIMEOUT 60000
 etcdctl set /CP/CP_PROXY_DOCKER_COMMAND "nginx -g 'daemon off;'"
-etcdctl set /CP/CP_SSL_CERT_LOCATION ""
 
 HOMEDIR=$(eval echo "~`whoami`")
 

--- a/v3/setup/capcom.sh
+++ b/v3/setup/capcom.sh
@@ -29,3 +29,4 @@ etcdctl set /CP/CP_PROXY_ENABLED true
 etcdctl set /CP/CP_PROXY_RESTART_SCRIPT /restart_nginx_docker.sh
 etcdctl set /CP/CP_PROXY_TIMEOUT 60000
 etcdctl set /CP/CP_PROXY_DOCKER_COMMAND "nginx -g 'daemon off;'"
+etcdctl set /CP/CP_SSL_CERT_LOCATION ""


### PR DESCRIPTION
Can't use a blank `""` in Dynamo, so needs to be the default here.
