### PR TITLE
v3/control-jenkins: lock to 1.6xx

### DIFF
--- a/v3/fleet/control-jenkins.service
+++ b/v3/fleet/control-jenkins.service
@@ -25,7 +25,7 @@ ExecStart=/usr/bin/bash -c \
   --env-file=/etc/environment \
   -p 8081:8080 \
   -u root \
-  jenkins'
+  jenkins:1.651.1'
 ExecStop=/usr/bin/docker stop jenkins
 
 [Install]


### PR DESCRIPTION
only changing in v3 - this is just for okta
