### PR TITLE
init: hard-lock script version

### DIFF
--- a/init
+++ b/init
@@ -53,9 +53,17 @@ etcdctl get /environment/SCRIPTS-FORK
 if [[ $? = 4 ]]; then
   # 4 == 404 - key not found
   # case where a node is joining a pre-existing cluster
-  SCRIPTS_REV=$(cd $SCRIPTDIR && git branch|grep '\*'|cut -d' ' -f2 && cd -)
+  SCRIPTS_REV=$(cd $SCRIPTDIR && git rev-parse HEAD)
   etcdctl set /environment/SCRIPTS-FORK adobe-platform
   etcdctl set /environment/SCRIPTS-SHA  $SCRIPTS_REV
+fi
+
+CURRENT_REV=$(cd $SCRIPTDIR && git rev-parse HEAD)
+CLUSTER_REV=$(etcdctl get /environment/SCRIPTS-SHA)
+if [[ "$CLUSTER_REV" != "$CURRENT_REV" ]]; then
+  cd $SCRIPTDIR && git reset --hard && git checkout $CLUSTER_REV
+  $SCRIPTDIR/init $1
+  exit 0
 fi
 
 # start services specified in $(etcdctl get /environment/services)


### PR DESCRIPTION
We're essentially feature complete (bare-bones deployment pipeline) so this is now needed since the majority of our work has been dealing with organiziation of data & service add-ons. Doing this will hard-lock clusters to a particular version of the scripts, which is good, and maintainers will force maintainers to  review changes and upgrade scripts manually (preferably via control-jenkins).
