### PR TITLE
Adding Sumo Logic Hostname Source

### DIFF
--- a/v3/opt/sumologic/sumologic-control.service
+++ b/v3/opt/sumologic/sumologic-control.service
@@ -9,7 +9,7 @@ User=core
 Restart=always
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
-ExecStartPre=/usr/bin/docker pull behance/sumo-test
+ExecStartPre=/usr/bin/docker pull behance/docker-sumologic
 ExecStartPre=-/usr/bin/docker kill sumologic-control
 ExecStartPre=-/usr/bin/docker rm -f sumologic-control
 ExecStart=/usr/bin/bash -c \
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/bash -c \
     -e SUMO_HOSTNAME=$($IP) \
     -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
     -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
-    behance/sumo-test"
+    behance/docker-sumologic"
 ExecStop=/usr/bin/docker stop sumologic-control
 
 [X-Fleet]

--- a/v3/opt/sumologic/sumologic-control.service
+++ b/v3/opt/sumologic/sumologic-control.service
@@ -9,7 +9,7 @@ User=core
 Restart=always
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
-ExecStartPre=/usr/bin/docker pull behance/docker-sumologic
+ExecStartPre=/usr/bin/docker pull behance/sumo-test
 ExecStartPre=-/usr/bin/docker kill sumologic-control
 ExecStartPre=-/usr/bin/docker rm -f sumologic-control
 ExecStart=/usr/bin/bash -c \
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/bash -c \
     -e SUMO_HOSTNAME=$($IP) \
     -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
     -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
-    behance/docker-sumologic"
+    behance/sumo-test"
 ExecStop=/usr/bin/docker stop sumologic-control
 
 [X-Fleet]

--- a/v3/opt/sumologic/sumologic-control.service
+++ b/v3/opt/sumologic/sumologic-control.service
@@ -4,6 +4,7 @@ After=docker.service bootstrap.service
 
 [Service]
 EnvironmentFile=/etc/environment
+Environment="IP=curl -sS http://169.254.169.254/latest/meta-data/local-ipv4"
 User=core
 Restart=always
 TimeoutStartSec=0
@@ -19,6 +20,7 @@ ExecStart=/usr/bin/bash -c \
     -e SUMO_NAME=docker_cluster \
     -e SUMO_CATEGORY=be/${NODE_PRODUCT}/${NODE_TIER}/control-logs \
     -e SUMO_COLLECTOR_NAME=mesos_app_collector \
+    -e SUMO_HOSTNAME=$($IP) \
     -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
     -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
     behance/docker-sumologic"

--- a/v3/opt/sumologic/sumologic-journald.service
+++ b/v3/opt/sumologic/sumologic-journald.service
@@ -6,6 +6,7 @@ After=docker.service bootstrap.service
 
 [Service]
 EnvironmentFile=/etc/environment
+Environment="IP=curl -sS http://169.254.169.254/latest/meta-data/local-ipv4"
 User=core
 Restart=always
 TimeoutStartSec=0
@@ -23,6 +24,7 @@ sudo /usr/bin/docker run --name sumologic-journald \
 -e SUMO_NAME=${NODE_PRODUCT}-${NODE_TIER}-cluster \
 -e SUMO_CATEGORY=be/${NODE_PRODUCT}/${NODE_TIER}/${NODE_ROLE}/journald-logs \
 -e SUMO_COLLECTOR_NAME=mesos_journald_collector \
+-e SUMO_HOSTNAME=$($IP) \
 -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
 -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
 behance/docker-sumologic:syslog-latest"

--- a/v3/opt/sumologic/sumologic-journald.service
+++ b/v3/opt/sumologic/sumologic-journald.service
@@ -11,7 +11,7 @@ User=core
 Restart=always
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
-ExecStartPre=/usr/bin/docker pull behance/docker-sumologic:syslog-latest
+ExecStartPre=/usr/bin/docker pull behance/sumo-test:syslog
 ExecStartPre=-/usr/bin/docker kill sumologic-journald
 ExecStartPre=-/usr/bin/docker rm -f sumologic-journald
 ExecStart=/usr/bin/bash -c \
@@ -27,7 +27,7 @@ sudo /usr/bin/docker run --name sumologic-journald \
 -e SUMO_HOSTNAME=$($IP) \
 -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
 -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
-behance/docker-sumologic:syslog-latest"
+behance/sumo-test:syslog"
 ExecStop=/usr/bin/docker stop sumologic-journald
 
 [X-Fleet]

--- a/v3/opt/sumologic/sumologic-journald.service
+++ b/v3/opt/sumologic/sumologic-journald.service
@@ -11,7 +11,7 @@ User=core
 Restart=always
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
-ExecStartPre=/usr/bin/docker pull behance/sumo-test:syslog
+ExecStartPre=/usr/bin/docker pull behance/docker-sumologic:syslog-latest
 ExecStartPre=-/usr/bin/docker kill sumologic-journald
 ExecStartPre=-/usr/bin/docker rm -f sumologic-journald
 ExecStart=/usr/bin/bash -c \
@@ -27,7 +27,7 @@ sudo /usr/bin/docker run --name sumologic-journald \
 -e SUMO_HOSTNAME=$($IP) \
 -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
 -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
-behance/sumo-test:syslog"
+behance/docker-sumologic:syslog-latest"
 ExecStop=/usr/bin/docker stop sumologic-journald
 
 [X-Fleet]

--- a/v3/opt/sumologic/sumologic.service
+++ b/v3/opt/sumologic/sumologic.service
@@ -9,7 +9,7 @@ User=core
 Restart=always
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
-ExecStartPre=/usr/bin/docker pull behance/docker-sumologic
+ExecStartPre=/usr/bin/docker pull behance/sumo-test
 ExecStartPre=-/usr/bin/docker kill sumologic
 ExecStartPre=-/usr/bin/docker rm -f sumologic
 ExecStart=/usr/bin/bash -c \
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/bash -c \
     -e SUMO_HOSTNAME=$($IP) \
     -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
     -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
-    behance/docker-sumologic"
+    behance/sumo-test"
 ExecStop=/usr/bin/docker stop sumologic
 
 [X-Fleet]

--- a/v3/opt/sumologic/sumologic.service
+++ b/v3/opt/sumologic/sumologic.service
@@ -4,6 +4,7 @@ After=docker.service bootstrap.service
 
 [Service]
 EnvironmentFile=/etc/environment
+Environment="IP=curl -sS http://169.254.169.254/latest/meta-data/local-ipv4"
 User=core
 Restart=always
 TimeoutStartSec=0
@@ -19,6 +20,7 @@ ExecStart=/usr/bin/bash -c \
     -e SUMO_NAME=docker_cluster \
     -e SUMO_CATEGORY=be/${NODE_PRODUCT}/${NODE_TIER}/container-logs \
     -e SUMO_COLLECTOR_NAME=mesos_app_collector \
+    -e SUMO_HOSTNAME=$($IP) \
     -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
     -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
     behance/docker-sumologic"

--- a/v3/opt/sumologic/sumologic.service
+++ b/v3/opt/sumologic/sumologic.service
@@ -9,7 +9,7 @@ User=core
 Restart=always
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
-ExecStartPre=/usr/bin/docker pull behance/sumo-test
+ExecStartPre=/usr/bin/docker pull behance/docker-sumologic
 ExecStartPre=-/usr/bin/docker kill sumologic
 ExecStartPre=-/usr/bin/docker rm -f sumologic
 ExecStart=/usr/bin/bash -c \
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/bash -c \
     -e SUMO_HOSTNAME=$($IP) \
     -e SUMO_ACCESS_ID=`etcdctl get /sumologic/config/access-id` \
     -e SUMO_ACCESS_KEY=`etcdctl get /sumologic/config/access-key` \
-    behance/sumo-test"
+    behance/docker-sumologic"
 ExecStop=/usr/bin/docker stop sumologic
 
 [X-Fleet]


### PR DESCRIPTION
- Added `SUMO_HOSTNAME` environment variable to sumo service files.
- When passed to Sumo (see https://github.com/behance/docker-sumologic/pull/2/files), will be used to set the `sourceHost` to the IP of the the host rather than the IP of the container.
