### PR TITLE
Bugfix add marathon authentication to docker-dd-agent-mesos service

### DIFF
--- a/v3/opt/datadog/datadog-control.service
+++ b/v3/opt/datadog/datadog-control.service
@@ -18,8 +18,8 @@ ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos -h `hostname` \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
 -e MESOS_HOST=`etcdctl get /environment/CONTROL_ELB` \
--e MARATHON_USERNAME=`etcdctl get /marathon/username` \
--e MARATHON_PASSWORD=`etcdctl get /marathon/password` \
+-e MARATHON_USERNAME=`etcdctl get /marathon/config/username` \
+-e MARATHON_PASSWORD=`etcdctl get /marathon/config/password` \
 behance/docker-dd-agent-mesos"
 ExecStop=/usr/bin/docker stop dd-agent-mesos
 

--- a/v3/opt/datadog/datadog-control.service
+++ b/v3/opt/datadog/datadog-control.service
@@ -18,6 +18,8 @@ ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos -h `hostname` \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
 -e MESOS_HOST=`etcdctl get /environment/CONTROL_ELB` \
+-e MARATHON_USERNAME=`etcdctl get /marathon/username` \
+-e MARATHON_PASSWORD=`etcdctl get /marathon/password` \
 behance/docker-dd-agent-mesos"
 ExecStop=/usr/bin/docker stop dd-agent-mesos
 


### PR DESCRIPTION
With the new marathon authentication added to mesos-systemd v3, the datadog agent running on the control node broke. This will add in the marathon username and password values from etcd into the docker container environmental variables.

https://github.com/behance/docker-dd-agent-mesos/pull/2
