### PR TITLE
Mesos Master Quorum Configurable Based on Control Tier Size

### DIFF
--- a/v3/fleet-local/control/mesos-master@.service
+++ b/v3/fleet-local/control/mesos-master@.service
@@ -36,7 +36,7 @@ ExecStart=/usr/bin/bash -c "sudo docker run \
   --cluster=$NODE_PRODUCT-$NODE_TIER \
   --hostname=$(curl -s http://169.254.169.254/latest/meta-data/local-hostname) \
   --log_dir=/var/log/mesos \
-  --quorum=3 \
+  --quorum=$((($CONTROL_CLUSTER_SIZE+1)/2)) \
   --work_dir=/var/lib/mesos/master \
   --zk=zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$($ZK_ENDPOINT)/mesos"
 


### PR DESCRIPTION
Removes hard coded "3" in favor of a quorum size calculation:

N = (Size + 1)/2

From: http://mesos.apache.org/documentation/latest/operational-guide/

This PR will allow us to use a control tier size of 3, 5, 7, etc. rather than just 5.
