### PR TITLE
Configurable Cgroup Sizing

### DIFF
--- a/v3/fleet-local/proxy/proxy@.service
+++ b/v3/fleet-local/proxy/proxy@.service
@@ -11,8 +11,10 @@ RestartSec=5
 TimeoutStartSec=0
 Environment="IMAGE=etcdctl get /images/proxy"  
 Environment="PROXY=etcdctl get /capcom/config/proxy"  
-Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"  
+Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"
+Environment="MEMORY=$((`grep MemTotal /proc/meminfo | awk '{print $2}'`*3/4/1048576))"
 
+ExecStartPre=/usr/bin/bash -c "if [ $MEMORY -eq 0 ]; then MEMORY=1; fi"
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill proxy
 ExecStartPre=-/usr/bin/docker rm proxy
@@ -22,7 +24,7 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
   echo $($CMD) | xargs docker run \
     --name proxy \
     --net='host' \
-    -m 12G \
+    -m $($MEMORY)G \
     -v /etc/$($PROXY):/etc/$($PROXY) \
     $($IMAGE)"
 

--- a/v3/fleet-local/proxy/proxy@.service
+++ b/v3/fleet-local/proxy/proxy@.service
@@ -14,7 +14,7 @@ Environment="PROXY=etcdctl get /capcom/config/proxy"
 Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"
 Environment="MEMORY=$((`grep MemTotal /proc/meminfo | awk '{print $2}'`*3/4/1048576))"
 
-ExecStartPre=/usr/bin/bash -c "if [ $MEMORY -eq 0 ]; then MEMORY=1; fi"
+ExecStartPre=/usr/bin/bash -c "if [[ $MEMORY -eq 0 || -z $MEMORY ]]; then MEMORY=1; fi"
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill proxy
 ExecStartPre=-/usr/bin/docker rm proxy

--- a/v3/fleet-local/proxy/proxy@.service
+++ b/v3/fleet-local/proxy/proxy@.service
@@ -12,19 +12,17 @@ TimeoutStartSec=0
 Environment="IMAGE=etcdctl get /images/proxy"  
 Environment="PROXY=etcdctl get /capcom/config/proxy"  
 Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"
-Environment="MEMORY=$((`grep MemTotal /proc/meminfo | awk '{print $2}'`*3/4/1048576))"
 
-ExecStartPre=/usr/bin/bash -c "if [[ $MEMORY -eq 0 || -z $MEMORY ]]; then MEMORY=1; fi"
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill proxy
 ExecStartPre=-/usr/bin/docker rm proxy
 
 # NOTE: it's critical to source the etcdctl.sh file so that etcd connects to the correct cluster.
-ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
+ExecStart=/usr/bin/bash -c "source /etc/profile.d/etcdctl.sh && \
   echo $($CMD) | xargs docker run \
     --name proxy \
     --net='host' \
-    -m $($MEMORY)G \
+    -m $(($(grep MemTotal /proc/meminfo | awk '{print $2}')*3/4/1024))M \
     -v /etc/$($PROXY):/etc/$($PROXY) \
     $($IMAGE)"
 


### PR DESCRIPTION
Proxy reloads can use a pre-defined maximum allotment of memory. When using c4.2xlarge instances, this was hard-coded as `12GB`. However, now that numerous instance sizes are supported, this value should be adjusted to ~75% of memory. This code dynamically calculates this value.
