### PR TITLE
add --security-opt=no-new-privileges to chronos.service

### DIFF
--- a/v3/fleet-local/control/chronos@.service
+++ b/v3/fleet-local/control/chronos@.service
@@ -32,6 +32,7 @@ ExecStart=/usr/bin/sh -c "docker run \
   -v /opt/mesos/framework-secret:/opt/mesos/framework-secret:ro \
   --env LIBPROCESS_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4) \
   --env LIBPROCESS_PORT=4401 \
+  --security-opt=no-new-privileges \
   $($IMAGE) \
   /usr/bin/chronos \
   run_jar \


### PR DESCRIPTION
A process can set the `no_new_priv` bit in the kernel. It persists across fork, clone and execve. The `no_new_priv` bit ensures that the process or its children processes do not gain any additional privileges via suid or sgid bits. This way a lot of dangerous operations become a lot less dangerous because there is no possibility of subverting privileged binaries. `no_new_priv` prevents LSMs like SELinux from transitioning to process labels that have access not allowed to the current process.
