### PR TITLE
RSA Key Check before Create

### DIFF
--- a/v3/util/setup-credentials.sh
+++ b/v3/util/setup-credentials.sh
@@ -24,7 +24,10 @@ sudo chown -R ${OWNER}:${OWNER} /home/${OWNER}/.dockercfg
 sudo cp /home/${OWNER}/.dockercfg /root/.dockercfg
 
 # Actually generate a private key
-ssh-keygen -f ${HOMEDIR}/.ssh/id_rsa -t rsa -N ''
+if [[ ! -f ${HOMEDIR}/.ssh/id_rsa ]]; then
+	ssh-keygen -f ${HOMEDIR}/.ssh/id_rsa -t rsa -N ''
+fi
+
 # ensure that we have a public key for our RSA key and that it's authorized
 ssh-keygen -f ${HOMEDIR}/.ssh/id_rsa -y > ${HOMEDIR}/.ssh/id_rsa.pub
 cat ${HOMEDIR}/.ssh/id_rsa.pub >> ${HOMEDIR}/.ssh/authorized_keys


### PR DESCRIPTION
- In preparation for potentially looping the init script, now check for the id_rsa key before creating it. If not, the command forces an interactive prompt (press Y to overwrite).
