### PR TITLE
Mount container root filesystem as read only as per CIS 5.12

### DIFF
--- a/v3/fleet-local/control/chronos@.service
+++ b/v3/fleet-local/control/chronos@.service
@@ -29,6 +29,7 @@ ExecStartPre=-/usr/bin/docker rm chronos
 ExecStart=/usr/bin/sh -c "docker run \
   --name chronos \
   --net=host \
+  --read-only \
   -v /opt/mesos/framework-secret:/opt/mesos/framework-secret:ro \
   --env LIBPROCESS_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4) \
   --env LIBPROCESS_PORT=4401 \


### PR DESCRIPTION
The container's root file system should be treated as a 'golden image' and any writes to the rootfilesystem should be avoided. You should explicitly define a container volume for writing. Add a `--read-only` flag to allow the container's root filesystem to bemounted as read only. This can be used in combination with volumes to force a container's process to only write to locations that will be persisted. refer: https://benchmarks.cisecurity.org/tools2/docker/CIS_Docker_1.11.0_Benchmark_v1.0.0.pdf
