### PR TITLE
fleet & util: fd-user creation scripts

### DIFF
--- a/v3/fleet/fd-users.service
+++ b/v3/fleet/fd-users.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Create application users based on flight-director keys
+After=etcd2.service
+
+[Service]
+User=core
+Restart=always
+TimeoutStartSec=0
+RestartSec=10
+
+ExecStart=/home/core/mesos-systemd/v2/util/fd-users.sh
+
+[Install]
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=true
+MachineMetadata=role=worker

--- a/v3/util/fd-users.sh
+++ b/v3/util/fd-users.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -f /etc/profile.d/etcdctl.sh ]]; then
+    source /etc/profile.d/etcdctl.sh
+fi
+
+etcdctl exec-watch /flight-director/users -- /usr/bin/bash -c \
+'for user in $ETCD_WATCH_VALUE; \
+do sudo useradd -p "*" -U -m $user -G docker; \
+done'


### PR DESCRIPTION
watch /flight-director/users for a string of "user1 user2 user3" usernames, use useradd to create them on worker instances.
