### PR TITLE
Switch v2 datadog-control.service to use docker-dd-agent-mesos:v2

### DIFF
--- a/v2/fleet/datadog-control.service
+++ b/v2/fleet/datadog-control.service
@@ -11,14 +11,14 @@ After=docker.service
 User=core
 Restart=always
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull behance/docker-dd-agent-mesos:latest
+ExecStartPre=/usr/bin/docker pull behance/docker-dd-agent-mesos:v2
 ExecStartPre=-/usr/bin/docker kill dd-agent-mesos
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos -h `hostname` \
 -e API_KEY=`etcdctl get /ddapikey` \
 -e MESOS_HOST=`etcdctl get /environment/CONTROL_ELB` \
-behance/docker-dd-agent-mesos"
+behance/docker-dd-agent-mesos:v2"
 ExecStop=/usr/bin/docker stop dd-agent-mesos
 
 [X-Fleet]


### PR DESCRIPTION
This is a change of mesos-systemd/v2 (Portfolio) to fix the version of docker-dd-agent-mesos on older clusters (Porfolio) to a fixed 'v2' branch, and then allow for updates and upgrades for docker-dd-agent-mesos agent on the latest ethos mesos-systemd/v3 to happen without breaking backwards compatibility on our older system. 
