### PR TITLE
Feature add dd agent mesos-master and mesos-slave

### DIFF
--- a/v3/fleet-local/worker/mesos-slave@.service
+++ b/v3/fleet-local/worker/mesos-slave@.service
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/bash -c "source /etc/profile.d/etcdctl.sh && \
     --net=host \
     --pid=host \
     --privileged \
+    -p 5051:5051 \
     -v /home/core/.dockercfg:/root/.dockercfg:ro \
     -v /sys:/sys \
     -v /usr/bin/docker:/usr/bin/docker:ro \

--- a/v3/opt/datadog/datadog-control.service
+++ b/v3/opt/datadog/datadog-control.service
@@ -18,8 +18,6 @@ ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos -h `hostname` \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
 -e MESOS_HOST=`etcdctl get /environment/CONTROL_ELB` \
--e MARATHON_USERNAME=`etcdctl get /marathon/config/username` \
--e MARATHON_PASSWORD=`etcdctl get /marathon/config/password` \
 behance/docker-dd-agent-mesos"
 ExecStop=/usr/bin/docker stop dd-agent-mesos
 

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -21,6 +21,8 @@ ExecStart=/usr/bin/bash -c \
 -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
 -e HOST_IP=`hostname -i` \
+-e MARATHON_USERNAME=`etcdctl get /marathon/config/username` \
+-e MARATHON_PASSWORD=`etcdctl get /marathon/config/password` \
 adobeplatform/docker-dd-agent-mesos-master"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-master
 

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -1,0 +1,25 @@
+# https://raw.githubusercontent.com/DataDog/docker-dd-agent/master/dd-agent.service
+# make sure the etcd /ddapikey is set!
+[Unit]
+Description=Datadog Agent for Mesos master
+After=docker.service
+
+[Service]
+# CONTROL_ELB should be set in etcd
+# It should be run on all mesos master nodes
+# Look at behance/docker-dd-agent-mesos for what ports those 3 should be running on
+User=core
+Restart=always
+TimeoutStartSec=0
+ExecStartPre=/usr/bin/docker pull index.docker.io/behance/docker-dd-agent-mesos-master:latest
+ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-master
+ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-master
+ExecStart=/usr/bin/bash -c \
+"if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-master -h `hostname` \
+-e API_KEY=`etcdctl get /datadog/config/api-key` \
+behance/docker-dd-agent-mesos-master"
+ExecStop=/usr/bin/docker stop dd-agent-mesos-master
+
+[X-Fleet]
+MachineMetadata=role=control
+MachineMetadata=role=it-hybrid

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -7,17 +7,17 @@ After=docker.service
 [Service]
 # CONTROL_ELB should be set in etcd
 # It should be run on all mesos master nodes
-# Look at behance/docker-dd-agent-mesos for what ports those 3 should be running on
+# Look at adobeplatform/docker-dd-agent-mesos for what ports those 3 should be running on
 User=core
 Restart=always
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull index.docker.io/behance/docker-dd-agent-mesos-master:latest
+ExecStartPre=/usr/bin/docker pull index.docker.io/adobeplatform/docker-dd-agent-mesos-master:latest
 ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-master
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-master
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-master -h `hostname` \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
-behance/docker-dd-agent-mesos-master"
+adobeplatform/docker-dd-agent-mesos-master"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-master
 
 [X-Fleet]

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -7,7 +7,7 @@ After=docker.service
 [Service]
 # CONTROL_ELB should be set in etcd
 # It should be run on all mesos master nodes
-# Look at adobeplatform/docker-dd-agent-mesos for what ports those 3 should be running on
+# Look at adobeplatform/docker-dd-agent-mesos-master for what ports those 3 should be running on
 User=core
 Restart=always
 TimeoutStartSec=0

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -25,5 +25,6 @@ adobeplatform/docker-dd-agent-mesos-master"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-master
 
 [X-Fleet]
+Global=true
 MachineMetadata=role=control
 MachineMetadata=role=it-hybrid

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -16,7 +16,11 @@ ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-master
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-master
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-master -h `hostname` \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v /proc/:/host/proc/:ro \
+-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
+-e HOST_IP=`hostname -i` \
 adobeplatform/docker-dd-agent-mesos-master"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-master
 

--- a/v3/opt/datadog/datadog-mesos-slave.service
+++ b/v3/opt/datadog/datadog-mesos-slave.service
@@ -16,7 +16,11 @@ ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-slave
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-slave
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-slave -h `hostname` \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v /proc/:/host/proc/:ro \
+-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
+-e HOST_IP=`hostname -i` \
 adobeplatform/docker-dd-agent-mesos-slave"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-slave
 

--- a/v3/opt/datadog/datadog-mesos-slave.service
+++ b/v3/opt/datadog/datadog-mesos-slave.service
@@ -1,0 +1,25 @@
+# https://raw.githubusercontent.com/DataDog/docker-dd-agent/master/dd-agent.service
+# make sure the etcd /ddapikey is set!
+[Unit]
+Description=Datadog Agent for Mesos slave
+After=docker.service
+
+[Service]
+# CONTROL_ELB should be set in etcd
+# It should be run on all mesos slave nodes (worker tier nodes)
+# Look at behance/docker-dd-agent-mesos for what ports those 3 should be running on
+User=core
+Restart=always
+TimeoutStartSec=0
+ExecStartPre=/usr/bin/docker pull index.docker.io/behance/docker-dd-agent-mesos-slave:latest
+ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-slave
+ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-slave
+ExecStart=/usr/bin/bash -c \
+"if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-slave -h `hostname` \
+-e API_KEY=`etcdctl get /datadog/config/api-key` \
+behance/docker-dd-agent-mesos-slave"
+ExecStop=/usr/bin/docker stop dd-agent-mesos-slave
+
+[X-Fleet]
+MachineMetadata=role=worker
+MachineMetadata=role=it-hybrid

--- a/v3/opt/datadog/datadog-mesos-slave.service
+++ b/v3/opt/datadog/datadog-mesos-slave.service
@@ -7,17 +7,17 @@ After=docker.service
 [Service]
 # CONTROL_ELB should be set in etcd
 # It should be run on all mesos slave nodes (worker tier nodes)
-# Look at behance/docker-dd-agent-mesos for what ports those 3 should be running on
+# Look at adobeplatform/docker-dd-agent-mesos for what ports those 3 should be running on
 User=core
 Restart=always
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull index.docker.io/behance/docker-dd-agent-mesos-slave:latest
+ExecStartPre=/usr/bin/docker pull index.docker.io/adobeplatform/docker-dd-agent-mesos-slave:latest
 ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-slave
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-slave
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-slave -h `hostname` \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
-behance/docker-dd-agent-mesos-slave"
+adobeplatform/docker-dd-agent-mesos-slave"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-slave
 
 [X-Fleet]

--- a/v3/opt/datadog/datadog-mesos-slave.service
+++ b/v3/opt/datadog/datadog-mesos-slave.service
@@ -25,5 +25,6 @@ adobeplatform/docker-dd-agent-mesos-slave"
 ExecStop=/usr/bin/docker stop dd-agent-mesos-slave
 
 [X-Fleet]
+Global=true
 MachineMetadata=role=worker
 MachineMetadata=role=it-hybrid

--- a/v3/opt/datadog/datadog-mesos-slave.service
+++ b/v3/opt/datadog/datadog-mesos-slave.service
@@ -7,7 +7,7 @@ After=docker.service
 [Service]
 # CONTROL_ELB should be set in etcd
 # It should be run on all mesos slave nodes (worker tier nodes)
-# Look at adobeplatform/docker-dd-agent-mesos for what ports those 3 should be running on
+# Look at adobeplatform/docker-dd-agent-mesos-slave for what ports those 3 should be running on
 User=core
 Restart=always
 TimeoutStartSec=0


### PR DESCRIPTION
This will add two new global docker-dd-mesos-master and docker-dd-mesos-slave units that mount a new datadog agent to control tier and worker tier, respectively. The datadog agents monitor mesos and marathon on each host.
