### PR TITLE
Mount container's root filesystem as read only

### DIFF
--- a/v3/fleet-local/control/cfn-signal@.service
+++ b/v3/fleet-local/control/cfn-signal@.service
@@ -18,6 +18,7 @@ ExecStartPre=/usr/bin/systemctl is-active marathon@*
 ExecStartPre=/usr/bin/sh -c "docker pull $($IMAGE)"
 ExecStartPre=/usr/bin/sh -c "/usr/bin/docker run --rm\
  $($IMAGE) cfn-signal\
+ --read-only \
  --stack $STACK_NAME\
  --region $($AZ|head -c-1)\
  --resource $CONTROL_ASG_NAME\

--- a/v3/fleet-local/control/flight-director@.service
+++ b/v3/fleet-local/control/flight-director@.service
@@ -18,6 +18,7 @@ ExecStartPre=-/usr/bin/docker rm flight-director
 ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   --name flight-director \
   --net='host' \
+  --read-only \
   -e LOG_APP_NAME=flight-director \
   -e FD_API_SERVER_PORT=`etcdctl get /flight-director/config/api-server-port` \
   -e FD_CHRONOS_MASTER=`etcdctl get /flight-director/config/chronos-master` \

--- a/v3/fleet-local/control/marathon@.service
+++ b/v3/fleet-local/control/marathon@.service
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   --name marathon \
   -e LIBPROCESS_PORT=9090 \
   --net=host \
+  --read-only \
   -v /opt/mesos/framework-secret:/opt/mesos/framework-secret:ro \
   $($IMAGE) \
   --mesos_authentication_principal $($MESOS_USERNAME) \

--- a/v3/fleet-local/control/mesos-master@.service
+++ b/v3/fleet-local/control/mesos-master@.service
@@ -27,6 +27,7 @@ ExecStart=/usr/bin/bash -c "sudo docker run \
   --name=mesos-master \
   --privileged \
   --net=host \
+  --read-only \
   -v /var/lib/mesos/master:/var/lib/mesos/master \
   -v /opt/mesos/credentials:/opt/mesos/credentials:ro \
   $($IMAGE) \

--- a/v3/fleet-local/control/zk-exhibitor@.service
+++ b/v3/fleet-local/control/zk-exhibitor@.service
@@ -20,6 +20,7 @@ ExecStartPre=-/usr/bin/docker rm zk-exhibitor
 
 ExecStart=/usr/bin/bash -c "sudo docker run \
   --name=zk-exhibitor \
+  --read-only \
   -p 8181:8181 \
   -p 2181:2181 \
   -p 2888:2888 \

--- a/v3/fleet-local/it-hybrid/flight-director@.service
+++ b/v3/fleet-local/it-hybrid/flight-director@.service
@@ -18,6 +18,7 @@ ExecStartPre=-/usr/bin/docker rm flight-director
 ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   --name flight-director \
   --net='host' \
+  --read-only \
   -e LOG_APP_NAME=flight-director \
   -e FD_API_SERVER_PORT=`etcdctl get /flight-director/config/api-server-port` \
   -e FD_CHRONOS_MASTER=`etcdctl get /flight-director/config/chronos-master` \

--- a/v3/fleet-local/it-hybrid/memcached.service
+++ b/v3/fleet-local/it-hybrid/memcached.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Proxy { Memcached } @ %i
-After=docker.service  
+After=docker.service
 Requires=docker.service
 
 
@@ -18,6 +18,7 @@ ExecStartPre=-/usr/bin/docker rm memcached
 ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
   echo $($CMD) | xargs docker run \
     --name memcached \
+    --read-only \
     borja/docker-memcached"
 
 ExecStop=-/usr/bin/docker stop memcached

--- a/v3/fleet-local/it-hybrid/proxy@.service
+++ b/v3/fleet-local/it-hybrid/proxy@.service
@@ -9,9 +9,9 @@ User=core
 Restart=always
 RestartSec=5
 TimeoutStartSec=0
-Environment="IMAGE=etcdctl get /images/proxy"  
-Environment="PROXY=etcdctl get /capcom/config/proxy"  
-Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"  
+Environment="IMAGE=etcdctl get /images/proxy"
+Environment="PROXY=etcdctl get /capcom/config/proxy"
+Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"
 
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill proxy
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
   echo $($CMD) | xargs docker run \
     --name proxy \
     --net='host' \
+    --read-only \
     -m 12G \
     -v /etc/$($PROXY):/etc/$($PROXY) \
     -v /home/core/ssl:/etc/$($PROXY)/ssl \

--- a/v3/fleet-local/proxy/capcom@.service
+++ b/v3/fleet-local/proxy/capcom@.service
@@ -11,7 +11,7 @@ RestartSec=20
 TimeoutStartSec=0
 EnvironmentFile=/etc/environment
 Environment="IMAGE=etcdctl get /images/capcom"
-Environment="PROXY=etcdctl get /capcom/config/proxy"  
+Environment="PROXY=etcdctl get /capcom/config/proxy"
 
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
 ExecStartPre=-/usr/bin/docker kill capcom
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
   docker run \
     --name capcom \
     --net='host' \
+    --read-only \
     --privileged \
     -v /etc/$($PROXY):/etc/$($PROXY) \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/v3/fleet-local/proxy/proxy@.service
+++ b/v3/fleet-local/proxy/proxy@.service
@@ -9,8 +9,8 @@ User=core
 Restart=always
 RestartSec=5
 TimeoutStartSec=0
-Environment="IMAGE=etcdctl get /images/proxy"  
-Environment="PROXY=etcdctl get /capcom/config/proxy"  
+Environment="IMAGE=etcdctl get /images/proxy"
+Environment="PROXY=etcdctl get /capcom/config/proxy"
 Environment="CMD=etcdctl get /capcom/config/proxy-docker-command"
 
 ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/bash -c "source /etc/profile.d/etcdctl.sh && \
   echo $($CMD) | xargs docker run \
     --name proxy \
     --net='host' \
+    --read-only \
     -m $(($(grep MemTotal /proc/meminfo | awk '{print $2}')*3/4/1024))M \
     -v /etc/$($PROXY):/etc/$($PROXY) \
     $($IMAGE)"

--- a/v3/fleet-local/worker/mesos-slave@.service
+++ b/v3/fleet-local/worker/mesos-slave@.service
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/bash -c "source /etc/profile.d/etcdctl.sh && \
   sudo docker run \
     --name=mesos-slave \
     --net=host \
+    --read-only \
     --pid=host \
     --privileged \
     -p 5051:5051 \

--- a/v3/fleet-manual/capcom2@.service
+++ b/v3/fleet-manual/capcom2@.service
@@ -17,6 +17,7 @@ ExecStart=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && \
   docker run \
     --name capcom2 \
     --net='host' \
+    --read-only \
     --privileged \
     -e LOG_APP_NAME=capcom \
     -e CP_APPLICATIONS=$(etcdctl get /capcom/config/applications) \

--- a/v3/fleet/control-jenkins.service
+++ b/v3/fleet/control-jenkins.service
@@ -17,6 +17,7 @@ ExecStartPre=-/usr/bin/docker rm jenkins
 ExecStart=/usr/bin/bash -c \
   '/usr/bin/docker run \
   --name jenkins \
+  --read-only \
   -v /home/core/.ssh:/var/jenkins_home/.ssh \
   -v /home/core/control-jenkins:/var/jenkins_home \
   -e RUNNING_HOST=`curl -s http://169.254.169.254/latest/meta-data/local-hostname` \

--- a/v3/fleet/control-proxy.service
+++ b/v3/fleet/control-proxy.service
@@ -18,6 +18,7 @@ ExecStartPre=-/usr/bin/docker rm control-proxy
 ExecStart=/usr/bin/bash -c \
   '/usr/bin/docker run \
   --name control-proxy \
+  --read-only \
   -e MESOS_MASTER_HOST=http://$($INTERNAL_CONTROL_ELB):5050 \
   -p 7070:80 \
   $($IMAGE)'

--- a/v3/fleet/logrotate.service
+++ b/v3/fleet/logrotate.service
@@ -12,7 +12,7 @@ ExecStartPre=/usr/bin/systemctl is-active bootstrap
 ExecStartPre=/usr/bin/docker pull index.docker.io/behance/docker-gocron-logrotate
 ExecStartPre=-/usr/bin/docker kill logrotate
 ExecStartPre=-/usr/bin/docker rm -f logrotate
-ExecStart=/usr/bin/sudo /usr/bin/docker run --name logrotate -v /var/lib/docker:/var/lib/docker behance/docker-gocron-logrotate
+ExecStart=/usr/bin/sudo /usr/bin/docker run --name logrotate --read-only -v /var/lib/docker:/var/lib/docker behance/docker-gocron-logrotate
 ExecStop=/usr/bin/docker stop logrotate
 
 [X-Fleet]

--- a/v3/opt/datadog/datadog-control.service
+++ b/v3/opt/datadog/datadog-control.service
@@ -16,6 +16,7 @@ ExecStartPre=-/usr/bin/docker kill dd-agent-mesos
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos -h `hostname` \
+--read-only \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
 -e MESOS_HOST=`etcdctl get /environment/CONTROL_ELB` \
 behance/docker-dd-agent-mesos"

--- a/v3/opt/datadog/datadog-mesos-master.service
+++ b/v3/opt/datadog/datadog-mesos-master.service
@@ -16,6 +16,7 @@ ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-master
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-master
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-master -h `hostname` \
+--read-only \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /proc/:/host/proc/:ro \
 -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \

--- a/v3/opt/datadog/datadog-mesos-slave.service
+++ b/v3/opt/datadog/datadog-mesos-slave.service
@@ -16,6 +16,7 @@ ExecStartPre=-/usr/bin/docker kill dd-agent-mesos-slave
 ExecStartPre=-/usr/bin/docker rm -f dd-agent-mesos-slave
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent-mesos-slave -h `hostname` \
+--read-only \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /proc/:/host/proc/:ro \
 -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \

--- a/v3/opt/datadog/datadog-proxy.service
+++ b/v3/opt/datadog/datadog-proxy.service
@@ -17,6 +17,7 @@ ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
 sudo /usr/bin/docker run --name dd-agent-proxy \
 --net='host' \
+--read-only \
 -e API_KEY=`etcdctl get /datadog/config/api-key` \
 -e PROXY=`etcdctl get /capcom/config/proxy` \
 behance/docker-dd-agent-proxy"

--- a/v3/opt/datadog/datadog.service
+++ b/v3/opt/datadog/datadog.service
@@ -15,6 +15,7 @@ ExecStartPre=-/usr/bin/docker kill dd-agent
 ExecStartPre=-/usr/bin/docker rm -f dd-agent
 ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && sudo /usr/bin/docker run --name dd-agent -h `hostname` \
+--read-only \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /proc/:/host/proc/:ro \
 -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \

--- a/v3/opt/ecr/aws-ecr-login.service
+++ b/v3/opt/ecr/aws-ecr-login.service
@@ -19,6 +19,7 @@ ExecStart=/bin/bash -c \
     docker run \
     --label com.swipely.iam-docker.iam-profile="$CONTAINERS_ROLE" \
     --name ecr-login \
+    --read-only \
     -e "TEMPLATE=templates/dockercfg.tmpl" \
     -e "AWS_REGION=`etcdctl get /ECR/config/region`" \
     -e "REGISTRIES=`etcdctl get /ECR/config/registry-account`" \

--- a/v3/opt/splunk/splunk-journald.service
+++ b/v3/opt/splunk/splunk-journald.service
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh; fi && \
 sudo /usr/bin/docker run --name splunk-journald \
 --hostname=${COREOS_PRIVATE_IPV4} \
+--read-only \
 -p 1514:1514/udp \
 -e SPLUNK_START_ARGS="--accept-license" \
 -e SPLUNK_FORWARD_SERVER=`etcdctl get /splunk/SPLUNK_FORWARD_SERVER` \

--- a/v3/opt/sumologic/sumologic-control.service
+++ b/v3/opt/sumologic/sumologic-control.service
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/bash -c \
     "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
     sudo /usr/bin/docker run --name sumologic-control \
     --hostname=$COREOS_PRIVATE_IPV4 \
+    --read-only \
     -v /var/lib/docker/containers/:/tmp/clogs/:ro \
     -e SUMO_NAME=docker_cluster \
     -e SUMO_CATEGORY=be/${NODE_PRODUCT}/${NODE_TIER}/control-logs \

--- a/v3/opt/sumologic/sumologic-journald.service
+++ b/v3/opt/sumologic/sumologic-journald.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/bash -c \
 "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
 sudo /usr/bin/docker run --name sumologic-journald \
 --hostname=$COREOS_PRIVATE_IPV4 \
+--read-only \
 -p 514:514 \
 -p 514:514/udp \
 -e PATH_EXPRESSION=/syslog/syslog \

--- a/v3/opt/sumologic/sumologic.service
+++ b/v3/opt/sumologic/sumologic.service
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/bash -c \
     "if [[ -f /etc/profile.d/etcdctl.sh ]]; then source /etc/profile.d/etcdctl.sh;fi && \
     sudo /usr/bin/docker run --name sumologic \
     --hostname=$COREOS_PRIVATE_IPV4 \
+    --read-only \
     -v /var/lib/docker/containers/:/tmp/clogs/:ro \
     -e SUMO_NAME=docker_cluster \
     -e SUMO_CATEGORY=be/${NODE_PRODUCT}/${NODE_TIER}/container-logs \

--- a/v3/util-units/etcd-peers.service
+++ b/v3/util-units/etcd-peers.service
@@ -5,7 +5,7 @@ Description=Write a file with the etcd peers that we should bootstrap to
 Restart=on-failure
 RestartSec=10
 ExecStartPre=/usr/bin/docker pull index.docker.io/monsantoco/etcd-aws-cluster:latest
-ExecStartPre=/usr/bin/docker run --rm -v /etc/sysconfig/:/etc/sysconfig/ monsantoco/etcd-aws-cluster:latest
+ExecStartPre=/usr/bin/docker run --rm --read-only -v /etc/sysconfig/:/etc/sysconfig/ monsantoco/etcd-aws-cluster:latest
 ExecStart=/usr/bin/systemctl start etcd2
 
 [Install]

--- a/v3/util-units/iam-proxy.service
+++ b/v3/util-units/iam-proxy.service
@@ -17,6 +17,7 @@ ExecStartPre=-/usr/bin/docker rm -f iam-proxy
 
 ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   --name=iam-proxy \
+  --read-only \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --restart=always \
   --net=host \


### PR DESCRIPTION
The container's root file system should be treated as a 'golden image' and any writes to the rootfilesystem should be avoided. You should explicitly define a container volume for writing. Add a `--read-only` flag to allow the container's root filesystem to bemounted as read only. This can be used in combination with volumes to force a container's process to only write to locations that will be persisted. refer: https://benchmarks.cisecurity.org/tools2/docker/CIS_Docker_1.11.0_Benchmark_v1.0.0.pdf
