### PR TITLE
hack for IT :(

### DIFF
--- a/init
+++ b/init
@@ -122,6 +122,6 @@ if [ "$NODE_ROLE" = "it-hybrid" ]; then
   fleetctl destroy docker-cleanup.service
   fleetctl destroy logrotate.service
   fleetctl destroy update-os.service
-  fleetctl fd-hud.service
+  fleetctl destroy fd-hud.service
 fi
 

--- a/init
+++ b/init
@@ -115,3 +115,13 @@ do
     submit-fleet-unit ${SCRIPTDIR}/$VERSION/fleet/${unit}
     sudo fleetctl start ${SCRIPTDIR}/$VERSION/fleet/${unit}
 done
+
+# hack to destroy harmful units on IT
+if [ "$NODE_ROLE" = "it-hybrid" ]; then
+  fleetctl destroy docker-cleanup.timer
+  fleetctl destroy docker-cleanup.service
+  fleetctl destroy logrotate.service
+  fleetctl destroy update-os.service
+  fleetctl fd-hud.service
+fi
+


### PR DESCRIPTION
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.
## Changelog

Remove units harmful for docker 1.10 on IT only.
## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Any docker containers introduced through your commit must not accumulate logs in an unsustainable manner.  In other words, no unmanaged logs that aren't/can't be rotated.  

If your PR relies on the default docker log driver, `json`, then this simply means ensuring all `docker run` commands are decorated with either/both of `--log-opt max-size=XX` / `--log-opt max-file=YY` (see the docker documentation for valid XX/YY values)

Did you introduce any command that executes `docker run`?

If you did, have you ensured that all your `docker run` using the default logger have either `max-size` and/or `max-file` set?

Are there any dependencies on github.com/adobe-platform/infrastructure? NO

If so:

Is an update to the base stack required(rare)? NO

Is an A/B required? NO

Are you dependent on new secrets, or infrastructure in any way? NO
