### PR TITLE
Update to ethos-systemd version of docker-cleanup

### DIFF
--- a/v2/util/docker-cleanup.sh
+++ b/v2/util/docker-cleanup.sh
@@ -1,28 +1,45 @@
 #!/bin/bash
 
-# NOTE: this script will need to be sudo'ed for access to /var/lib/docker
+echo "==== Removing images"
+# generate system images list
+# Note: no etcdauth in mesos-systemd
+for i in $(etcdctl ls images); do
+    etcdctl get $i|sed -e 's/index.docker.io\///g'|sed -e 's/\:.*//g';
+done > systemImages
+# these two are from other unit files that do not use etcd /images
+echo "aquasec/agent-data" >> systemImages
+echo "behance/iam-docker" >> systemImages
 
-echo "Removing dead containers & volumes"
-docker rm -v $(docker ps -a|grep Exited|cut -d" " -f1) 2> /dev/null
+# images that currently exist on host
+docker images -a|grep -v -e 'REPOSITORY'|awk '{print $1}'|tr " " "\n" > existingImages
 
-echo "Removing images"
-docker rmi $(docker images -aq) 2> /dev/null
+# list of images that exist on host, not in systemImages list
+deletionCandidates=$(comm -23 <(sort existingImages) <(sort systemImages))
 
-# play on https://github.com/docker/docker/issues/6354#issuecomment-114688663
+if [ -z "$deletionCandidates" ]; then
+    echo "No images to delete."
+else
+    echo "Going to attempt to delete images:"
+    docker images -a|egrep "$(echo $deletionCandidates| sed -e 's/ /\|/g')" > deleting
+    cat deleting
+    docker rmi $(cat deleting|awk '{print $3}')
+    rm deleting systemImages existingImages
+fi
+
+echo "==== Removing dead containers & volumes"
+docker rm -v $(docker ps -a -q) 2> /dev/null | xargs -n 1 -IXX echo "docker: Removing dead container XX"
+
+echo "==== Removing remaining [orphaned] volumes"
+docker volume rm $(docker volume ls -q) 2> /dev/null | xargs -n 1 -IXX echo "docker: Removing dead volume XX"
+
 FSDRIVER=$(docker info|grep Storage|cut -d: -f2|tr -d [:space:])
-FSLOC=/var/lib/docker/${FSDRIVER}
-cd $FSLOC
-echo "Starting image cleaning for driver:$FSDRIVER in $FSLOC"
-for image in $(ls|grep -v -- '-init'|cut -f2); do
-    docker inspect $image > /dev/null
-    if [ $? == 0 ]; then
-        echo "--> skipping $image"
-        continue
-    fi
-    echo "--> removing $image"
-    rm -r $image;
-done
-
+echo "Driver $FSDRIVER"
 echo "---- Complete ----"
+
 sudo free -h
-sudo df -Th
+if [ "$FSDRIVER" = "devicemapper" ]; then
+    sudo lvdisplay | grep Allocated | xargs -n 1 -IXX echo "docker lvm XX"
+    docker info | grep Data | xargs -n 1 -IXX echo "docker XX"
+else
+    sudo df -Th
+fi


### PR DESCRIPTION
## Changelog

Update to ethos-systemd version of docker-cleanup, minus etcdauth

## Notes

With newer docker version / CoreOS AMI, the old docker-cleanup script is clobbering the docker images, preventing `docker logs` from working properly.

Did you introduce any command that executes `docker run`?
No

Are there any dependencies on github.com/adobe-platform/infrastructure?
No

Is an update to the base stack required(rare)?
No

Is an A/B required?
No

Are you dependent on new secrets, or infrastructure in any way?
No
